### PR TITLE
use graphql loader to import graphql files, so we can use fragments

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,10 @@
 import { defineConfig } from 'astro/config';
+import graphql from '@rollup/plugin-graphql';
 
 // https://astro.build/config
 export default defineConfig({
   server: { port: 4323 }, // 4323 is "head" in T9
+  vite: {
+    plugins: [graphql()]
+  }
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "head-start",
       "version": "0.0.1",
       "dependencies": {
+        "@rollup/plugin-graphql": "^2.0.3",
         "astro": "^2.10.1",
         "rosetta": "^1.1.0"
       },
@@ -5038,6 +5039,53 @@
       "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
       "dev": true
     },
+    "node_modules/@rollup/plugin-graphql": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-graphql/-/plugin-graphql-2.0.3.tgz",
+      "integrity": "sha512-IuuELo+0t29adRuLVg8izBFiUXFSFw8BmezespscynRfvfXSOV0S7g8RzQt75VzP6KHHVmNmlAgz+8qlkLur3w==",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "graphql-tag": "^2.12.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.9.0",
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.4.tgz",
+      "integrity": "sha512-0KJnIoRI8A+a1dqOYLxH8vBf8bphDmty5QvIm2hqm7oFCFYKCAZWWd2hXgMibaPsNDhI0AtpYfQZJG47pt/k4g==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -5156,6 +5204,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/dom-view-transitions/-/dom-view-transitions-1.0.1.tgz",
       "integrity": "sha512-A9S1ijj/4MX06I1W/6on8lhaYyq1Ir7gaOvfllW1o4RzVWW88HAeqX0pUx9VgOLnNpdiGeUW2CTkg18p5LWIrA=="
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
     },
     "node_modules/@types/hast": {
       "version": "2.3.5",
@@ -8462,7 +8515,6 @@
       "version": "16.8.1",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
       "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -8528,7 +8580,6 @@
       "version": "2.12.6",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
       "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -18943,6 +18994,32 @@
       "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
       "dev": true
     },
+    "@rollup/plugin-graphql": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-graphql/-/plugin-graphql-2.0.3.tgz",
+      "integrity": "sha512-IuuELo+0t29adRuLVg8izBFiUXFSFw8BmezespscynRfvfXSOV0S7g8RzQt75VzP6KHHVmNmlAgz+8qlkLur3w==",
+      "requires": {
+        "@rollup/pluginutils": "^5.0.1",
+        "graphql-tag": "^2.12.6"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.4.tgz",
+      "integrity": "sha512-0KJnIoRI8A+a1dqOYLxH8vBf8bphDmty5QvIm2hqm7oFCFYKCAZWWd2hXgMibaPsNDhI0AtpYfQZJG47pt/k4g==",
+      "requires": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -19052,6 +19129,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/dom-view-transitions/-/dom-view-transitions-1.0.1.tgz",
       "integrity": "sha512-A9S1ijj/4MX06I1W/6on8lhaYyq1Ir7gaOvfllW1o4RzVWW88HAeqX0pUx9VgOLnNpdiGeUW2CTkg18p5LWIrA=="
+    },
+    "@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
     },
     "@types/hast": {
       "version": "2.3.5",
@@ -21486,7 +21568,6 @@
       "version": "16.8.1",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
       "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
-      "dev": true,
       "peer": true
     },
     "graphql-config": {
@@ -21533,7 +21614,6 @@
       "version": "2.12.6",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
       "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "dev": true,
       "requires": {
         "tslib": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint . --ext .js,.ts,.astro"
   },
   "dependencies": {
+    "@rollup/plugin-graphql": "^2.0.3",
     "astro": "^2.10.1",
     "rosetta": "^1.1.0"
   },

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -3,7 +3,7 @@ import type { DefaultLayoutQuery } from '../lib/datocms.d'
 import { datocmsRequest } from '../lib/datocms'
 import { setLocale, t } from '../lib/i18n'
 import DynamicTag from '../components/DynamicTag.astro'
-import query from './default.query.graphql?raw'
+import query from './default.query.graphql'
 import LocaleSelector from '../components/LocaleSelector/LocaleSelector.astro'
 
 const locale = setLocale(Astro.params.locale)

--- a/src/lib/datocms.ts
+++ b/src/lib/datocms.ts
@@ -1,5 +1,8 @@
+import { print } from 'graphql/language/printer';
+import type { DocumentNode } from 'graphql';
+
 type DatocmsRequestType = {
-  query: string;
+  query: DocumentNode;
   variables?: { [key: string]: string };
 };
 
@@ -13,7 +16,7 @@ export const datocmsRequest = ({ query, variables = {} }: DatocmsRequestType) =>
       'X-Exclude-Invalid': 'true', // https://www.datocms.com/docs/content-delivery-api/api-endpoints#strict-mode-for-non-nullable-graphql-types
       // "X-Include-Drafts": preview ? "true" : "false",
     },
-    body: JSON.stringify({ query, variables }),
+    body: JSON.stringify({ query: print(query), variables }),
   })
     .then((response) => response.json())
     .then((response) => {


### PR DESCRIPTION
# Changes

Import graphql files without ?raw and use @rollup/plugin-graphql to load graphql files. This gives us the ability to load fragments

~# Associated issue~

# How to test

Import a graphql file without ?raw anmd it should still work

# Checklist

- [x] I have performed a self-review of my own code!
~- [ ] I have made sure that my PR is easy to review (not too big, includes comments)~
~- [ ] I have added/updated tests to prove that my feature works (if not possible please explain why)~
~- [ ] I have made changes to the README and if the change affects the project setup (npm commands changed, new service added, environmental variable added)~
~- [ ] I have added a decision log entry if the change affects the architecture or changes a significant technology~
~- [ ] I have notified a reviewer~

