### PR TITLE
decision log: no JS framework in Head Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Inside of this project, you'll see the following folders and files:
 ```
 /
 ├── config/
+├── docs/
+│   └── decision-log/
 ├── public/
 │   └── favicon.svg
 ├── src/
@@ -75,6 +77,8 @@ Inside of this project, you'll see the following folders and files:
 └── package.json
 ```
 
+- `docs/` contains project documentation.
+  - `decision-log/` lists all key decisions made during the project. Please read the log so you understand why decisions are made and document key decisions when you make them.
 - `src/` contains all website source files that will be handled by Astro.
   - `pages/` - [Pages](https://docs.astro.build/en/core-concepts/astro-pages/) are organised by file system routing and are paired with GraphQL query files for data loading.
   - `components/` - [Components](https://docs.astro.build/en/core-concepts/astro-components/) are the elements the website is composed of. This can be Astro and framework specific components.

--- a/docs/decision-log/2023-10-27-no-js-framework.md
+++ b/docs/decision-log/2023-10-27-no-js-framework.md
@@ -1,0 +1,13 @@
+# No JS Framework
+
+**We've decided to only use Astro components and minimal vanilla JS and not bind Head Start to a specific JS framework.**
+
+- Date: 2023-10-27
+- Alternatives Considered: Preact (3kb React replacement, JSX templating similar to Astro), Svelte (lightweight output, no framework runtime)
+- Decision Made By: [Jasper](https://github.com/jbmoelker), [Declan](https://github.com/decrek), [Sjoerd](https://github.com/sjoerdbeentjes)
+
+## Decision
+
+Aim of Head Start is to provide a generic template for different websites. This means we want project authors that use Head Start to decide if and which JS framework flavour (React, Vue, Svelte). As such we've decided to only use Astro components and minimal vanilla JS and not bind Head Start to a specific JS framework.
+
+We've considered Preact and Svelte as lightweight JS frameworks. But have decided it's better to leave that choice to project authors.

--- a/docs/decision-log/README.md
+++ b/docs/decision-log/README.md
@@ -1,0 +1,27 @@
+# Decision Log
+
+These documents are used to track key decisions that are made during the course of the project. This can be used at a later stage to understand why decisions were made and by whom.
+
+You should add an entry to the decision log if you have:
+- Made a decision to use a specific technology which could have significant impact on how folks work in this repo
+- Changed a technology that was in use before in favour of a new one
+- Made a decision _not_ to use a technology for a specific reason
+- Solved a problem in a way which may appear peculiar/confusing without wider context
+
+## Log template
+
+Save entry as `[YYYY-MM-DD]-[name-slug]` (for example `2022-02-15-deploy-pr-only.md`):
+
+```md
+# [Title]
+
+**[Brief summary of decision]**
+
+- Date: [yyyy-mm-dd]
+- Alternatives Considered: [Alternatives]
+- Decision Made By: [Human]
+
+## Decision
+
+[Explain the decision in more detail]
+```


### PR DESCRIPTION
# Changes

- adds decision log
- introduces decision log in project README
- adds decision log entry for decision to not use a JS framework in Head Start but use Astro templates and minimal vanilla JS instead

# Associated issue

N/A

# How to test

Read the updated readme and decision log

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- ~~[ ] I have added/updated tests to prove that my feature works (if not possible please explain why)~~
- [x] I have made changes to the README and if the change affects the project setup (npm commands changed, new service added, environmental variable added)
- [x] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
