### PR TITLE
chore: i18n middleware

### DIFF
--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -1,7 +1,7 @@
 ---
 import type { DefaultLayoutQuery, SiteLocale, Tag } from '../lib/types/datocms';
 import { datocmsRequest } from '../lib/datocms';
-import { setLocale } from '../lib/i18n';
+import { defaultLocale } from '../lib/i18n';
 import query from './default.query.graphql';
 import IconSprite from '../components/Icon/IconSprite.astro';
 import LocaleSelector from '../components/LocaleSelector/LocaleSelector.astro';
@@ -16,8 +16,11 @@ interface Props {
   pageUrls: PageUrl[];
   seoMetaTags: Tag[];
 }
+type Params = { 
+  locale?: SiteLocale
+};
 
-const locale = setLocale(Astro.params.locale);
+const { locale = defaultLocale } = Astro.params as Params;
 const data = await datocmsRequest<DefaultLayoutQuery>({ query, variables: { locale } });
 const { pageUrls, seoMetaTags } = Astro.props;
 const mainContentId = 'content';

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -13,7 +13,9 @@ export function getLocale() {
   return i18n.locale();
 }
 
-export function setLocale(locale?: string) {
-  const newLocale = locale || defaultLocale;
-  return i18n.locale(newLocale);
+export function setLocale(locale: string = '') {
+  if (locales.includes(locale)) {
+    return i18n.locale(locale);
+  }
+  return i18n.locale();
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,11 @@
+import { defineMiddleware, sequence } from 'astro/middleware';
+import { setLocale } from './lib/i18n';
+
+const i18n = defineMiddleware(async ({ params }, next) => {
+  if (params.locale) {
+    setLocale(params.locale);
+  }
+  return next();
+});
+
+export const onRequest = sequence(i18n);

--- a/src/pages/[locale]/404.astro
+++ b/src/pages/[locale]/404.astro
@@ -3,7 +3,7 @@ import { datocmsRequest } from '../../lib/datocms';
 import type { NotFoundQuery } from '../../lib/types/datocms.d.ts';
 import query from './404.query.graphql';
 import Layout from '../../layouts/Default.astro';
-import { locales, setLocale } from '../../lib/i18n';
+import { locales } from '../../lib/i18n';
 import { noIndexTag, titleTag } from '../../lib/seo';
 
 export async function getStaticPaths() {
@@ -12,7 +12,7 @@ export async function getStaticPaths() {
   }));
 }
 
-const locale = setLocale(Astro.params.locale);
+const { locale } = Astro.params;
 const { page } = await datocmsRequest<NotFoundQuery>({ query, variables: { locale } });
 ---
 <Layout

--- a/src/pages/[locale]/[slug]/index.astro
+++ b/src/pages/[locale]/[slug]/index.astro
@@ -4,8 +4,8 @@ import type { SlugPathsQuery, PageQuery } from '../../../lib/types/datocms.d.ts'
 import slugPathsQuery from './paths.query.graphql';
 import pageQuery from './index.query.graphql';
 import Layout from '../../../layouts/Default.astro';
-import Blocks from '../../../blocks/Blocks.astro';import ShareButton from '../../../components/ShareButton/ShareButton.astro';
-import { setLocale } from '../../../lib/i18n';
+import Blocks from '../../../blocks/Blocks.astro';
+import ShareButton from '../../../components/ShareButton/ShareButton.astro';
 
 export async function getStaticPaths() {
   const data = await datocmsRequest<SlugPathsQuery>({ query: slugPathsQuery });
@@ -15,7 +15,7 @@ export async function getStaticPaths() {
   })));
 }
 
-const locale = setLocale(Astro.params.locale);
+const { locale } = Astro.params;
 const { page } = await datocmsRequest<PageQuery>({ query: pageQuery, variables: { locale, slug: Astro.params.slug } });
 const pageUrls = page._allSlugLocales.map(slug => ({ locale: slug.locale, pathname: `/${slug.locale}/${slug.value}/` }));
 ---

--- a/src/pages/[locale]/index.astro
+++ b/src/pages/[locale]/index.astro
@@ -5,13 +5,13 @@ import homeQuery from './index.query.graphql';
 import Layout from '../../layouts/Default.astro';
 import Blocks from '../../blocks/Blocks.astro';
 import ShareButton from '../../components/ShareButton/ShareButton.astro';
-import { locales, setLocale } from '../../lib/i18n';
+import { locales } from '../../lib/i18n';
 
 export async function getStaticPaths() {
   return locales.map(locale => ({ params: { locale } }));
 }
 
-const locale = setLocale(Astro.params.locale);
+const { locale } = Astro.params;
 const { page } = await datocmsRequest<HomeQuery>({ query: homeQuery, variables: { locale } });
 const pageUrls = locales.map(locale => ({ locale, pathname: `/${locale}/` }));
 ---


### PR DESCRIPTION
# Changes

- Use `setLocale` in middleware, so the logic doesn't have to be repeated in every page route and layout template.

# Associated issue

N/A

# How to test

1. Open preview link
2. Switch between locales
3. Verify translations switch along with the locale
4. Repeat on a generic page

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- ~~I have added/updated tests to prove that my feature works (if not possible please explain why)~~
- ~~I have made changes to the README and if the change affects the project setup (npm commands changed, new service added, environmental variable added)~~ (will add to `docs/i18n` PR)
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [x] I have notified a reviewer
