### PR TITLE
fix: run DatoCMS migrations

### DIFF
--- a/config/datocms/tsconfig.json
+++ b/config/datocms/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "importHelpers": true,
+    "module": "commonjs",
+    "strict": true,
+    "target": "es2019"
+  }
+}

--- a/datocms.config.json
+++ b/datocms.config.json
@@ -1,11 +1,12 @@
 {
-    "profiles": {
-      "default": {
-        "logLevel": "NONE",
-        "migrations": {
-          "directory": "./config/datocms/migrations",
-          "modelApiKey": "schema_migration"
-        }
+  "profiles": {
+    "default": {
+      "logLevel": "NONE",
+      "migrations": {
+        "directory": "./config/datocms/migrations",
+        "modelApiKey": "schema_migration",
+        "tsconfig": "./config/datocms/tsconfig.json"
       }
     }
   }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "head-start",
-  "type": "module",
   "version": "0.0.1",
   "scripts": {
     "astro": "astro",


### PR DESCRIPTION
# Changes

- Uses own TS config for DatoCMS migrations (`config/datocms/tsconfig.json`) so it doesn't conflict with the TS config for the rest of the project (`/tsconfig.json`).
- Removes `"type": "module"` from `package.json` so DatoCMS migrations correctly parse migration TS files.
- [ ] Resolves specific errors thrown when running `npm migrations:run ...`.
- [ ] Removes warning on running migrations from `docs/getting-started.md`.

<!-- example:
- Fixes wrong color in button
- Adds a new page
-->

# Associated issue

Resolves #62 .

# How to test

<!-- example:
1. Open preview link
2. Navigate to ...
3. Tap on ...
4. Verify that ...
5. Etc ...
-->

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] I have added/updated tests to prove that my feature works (if not possible please explain why)
- [ ] I have made changes to the README and if the change affects the project setup (npm commands changed, new service added, environmental variable added)
- [ ] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [ ] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
