### PR TITLE
fix: do not prerender preview api routes

### DIFF
--- a/src/pages/api/preview/enter.ts
+++ b/src/pages/api/preview/enter.ts
@@ -1,6 +1,8 @@
 import type { APIRoute } from 'astro';
 import { hashSecret, previewCookieName } from '../../../middleware';
 
+export const prerender = false;
+
 export const cookiePath = '/';
 
 export const GET: APIRoute = async ({ cookies, locals, request }) => {

--- a/src/pages/api/preview/exit.ts
+++ b/src/pages/api/preview/exit.ts
@@ -2,6 +2,8 @@ import type { APIRoute } from 'astro';
 import { previewCookieName } from '../../../middleware';
 import { cookiePath } from './enter';
 
+export const prerender = false;
+
 export const GET: APIRoute = ({ cookies, request }) => {
 
   cookies.delete(previewCookieName, {


### PR DESCRIPTION
# Changes

Fixes failing deploys caused by Cloudflare trying to prerender preview API routes.

# Associated issue

N/A

# How to test

Verify deploy succeeds.

# Checklist

- [x] I have performed a self-review of my own code
- [X] I have made sure that my PR is easy to review (not too big, includes comments)
- ~~I have made updated relevant documentation files (in project README, docs/, etc)~~
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- ~~I have notified a reviewer~~

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
