### PR TITLE
feature: Video Embed Block A11y

### DIFF
--- a/src/blocks/VideoEmbedBlock/VideoEmbedBlock.astro
+++ b/src/blocks/VideoEmbedBlock/VideoEmbedBlock.astro
@@ -68,6 +68,7 @@ function getVideoUrl({ loop, mute, video }: { loop: boolean; mute: boolean; vide
         video.providerUid
       }?${new URLSearchParams({
         autoplay: binaryBoolean(autoplay),
+        autopause: binaryBoolean(!autoplay),
         muted: binaryBoolean(mute),
         loop: binaryBoolean(loop),
       })}`

--- a/src/blocks/VideoEmbedBlock/VideoEmbedBlock.client.ts
+++ b/src/blocks/VideoEmbedBlock/VideoEmbedBlock.client.ts
@@ -2,35 +2,53 @@
 // so we use a custom element to porgressively enhance each instance:
 // @ see https://docs.astro.build/en/guides/client-side-scripts/#web-components-with-custom-elements
 class VideoEmbed extends HTMLElement {
+  #anchor: HTMLAnchorElement;
+  #autoplay = false;
+  #iframe: HTMLIFrameElement;
+  #isPlaying = false;
+  #videoUrl: string;
+
   constructor() {
     super();
-    const anchor = this.querySelector('a') as HTMLAnchorElement;
-    const iframe = this.querySelector('iframe') as HTMLIFrameElement;
-    const { autoplay, videoUrl } = this.dataset;
+    this.#anchor = this.querySelector('a') as HTMLAnchorElement;
+    this.#iframe = this.querySelector('iframe') as HTMLIFrameElement;
+    this.#autoplay = this.dataset.autoplay === 'true';
+    this.#videoUrl = this.dataset.videoUrl as string;
+  }
 
-    if (!anchor || !iframe || !videoUrl) {
-      console.warn('VideoEmbedBlock: missing required elements/attributes', { anchor, iframe, videoUrl });
+  connectedCallback() {
+    if (!this.#anchor || !this.#iframe || !this.#videoUrl) {
+      console.warn('VideoEmbedBlock: missing required elements/attributes', this);
       return;
     }
 
-    let isPlaying = false;
-    function play({ focus }: { focus: boolean }) {
-      if (isPlaying) return;
-      iframe.src = videoUrl as string;
-      iframe.removeAttribute('hidden');
-      anchor.setAttribute('hidden', '');
-      isPlaying = true;
-      if (focus) {
-        iframe.focus();
-      }
+    this.#anchor.addEventListener('click', this.#onClick.bind(this));
+
+    const useReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (this.#autoplay && !useReducedMotion) {
+      this.play({ focus: false });
     }
-    anchor.addEventListener('click', (event) => {
-      event.preventDefault();
-      play({ focus: true });
-    });
-    if (autoplay) {
-      play({ focus: false });
+  }
+
+  disconnectedCallback() {
+    this.#anchor.removeEventListener('click', this.#onClick.bind(this));
+  }
+
+  #onClick(event: MouseEvent) {
+    event.preventDefault();
+    this.play({ focus: true });
+  }
+
+  play({ focus }: { focus: boolean }) {
+    if (this.#isPlaying) return;
+    this.#iframe.src = this.#videoUrl;
+    this.#iframe.removeAttribute('hidden');
+    this.#anchor.setAttribute('hidden', '');
+    this.#isPlaying = true;
+    if (focus) {
+      this.#iframe.focus();
     }
   }
 }
+
 customElements.define('video-embed', VideoEmbed);


### PR DESCRIPTION
# Changes

- Only autoplays after checking `prefers-reduced-motion` for improved a11y.
- Improves custom element setup separating (dis)connectedCallback, props en methods.

# Associated issue

N/A

# How to test

Same steps as #38 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- ~~I have made updated relevant documentation files (in project README, docs/, etc)~~
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [ ] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
