### PR TITLE
feature: Consent Form

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "prettier.jsxSingleQuote": true,
+  "prettier.singleQuote": true
+}

--- a/src/components/ConsentForm/ConsentForm.astro
+++ b/src/components/ConsentForm/ConsentForm.astro
@@ -1,0 +1,134 @@
+---
+import SwitchInput from '@components/SwitchInput/SwitchInput.astro';
+import '@assets/a11y.css';
+
+const groups = [
+  {
+    key: 'functional',
+    title: 'Functional',
+    items: [
+      {
+        key: 'hs-locale',
+        title: 'Preferred language',
+        text: 'Remembers your preferred language.',
+        default: true,
+      },
+    ],
+  },
+  {
+    key: 'external-content',
+    title: 'External content',
+    items: [
+      {
+        key: 'x-twitter',
+        title: 'X (Twitter)',
+        text: 'Embed tweets. Includes analytics.',
+        default: false,
+      },
+      {
+        key: 'youtube',
+        title: 'YouTube',
+        text: 'Embed videos. Includes analytics.',
+        default: false,
+      },
+    ],
+  },
+  {
+    key: 'analytics',
+    title: 'Analytics',
+    items: [
+      {
+        key: 'plausible',
+        title: 'Plausible',
+        text: 'Collects anonymous data about website usage.',
+        default: false,
+      },
+    ],
+  },
+];
+---
+
+<form>
+  <h2>[ Consent form ]</h2>
+  {
+    groups.map((group) => (
+      <consent-form-group>
+        <fieldset>
+          <details>
+            <summary>
+              <legend>{group.title}</legend>
+              <label for={`consent:${group.key}`} class="a11y-sr-only">
+                {group.title}
+              </label>
+              <SwitchInput 
+                id={`consent:${group.key}`}
+                checked={group.items.every((item) => item.default)}
+                hidden
+              />
+            </summary>
+            <ul>
+              {group.items.map((item) => (
+                <li>
+                  <div>
+                    <label for={`consent:${group.key}:${item.key}`}>
+                      {item.title}
+                    </label>
+                    <p id={`consent:${group.key}:${item.key}:hint`}>
+                      {item.text}
+                    </p>
+                  </div>
+                  <SwitchInput
+                    id={`consent:${group.key}:${item.key}`}
+                    aria-describedby={`consent:${group.key}:${item.key}:hint`}
+                    name={`${group.key}:${item.key}`}
+                    checked={item.default}
+                  />
+                </li>
+              ))}
+            </ul>
+          </details>
+        </fieldset>
+      </consent-form-group>
+    ))
+  }
+</form>
+
+<script src="./ConsentForm.client.ts"></script>
+
+<style>
+  form {
+    max-width: 480px;
+  }
+  fieldset {
+    padding: 0;
+  }
+  summary,
+  li {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  summary > *:first-child,
+  li > *:first-child {
+    display: block;
+    width: 100%;
+    background: yellow;
+  }
+  legend {
+    font-weight: bold;
+    padding: 10px;
+    cursor: pointer;
+  }
+
+  li:not(:last-child) {
+    margin-bottom: 10px;
+  }
+  label {
+    display: block;
+    font-weight: bold;
+    cursor: pointer;
+  }
+  li p {
+    margin-block: .2em;
+  }
+</style>

--- a/src/components/ConsentForm/ConsentForm.astro
+++ b/src/components/ConsentForm/ConsentForm.astro
@@ -49,14 +49,15 @@ const groups = [
 ---
 
 <form>
-  <h2>[ Consent form ]</h2>
+  <h1>[ Consent form ]</h1>
   {
     groups.map((group) => (
       <consent-form-group>
         <fieldset>
+          <legend class="a11y-sr-only">{group.title}</legend>
           <details>
             <summary>
-              <legend>{group.title}</legend>
+              <span aria-hidden>{group.title}</span>
               <label for={`consent:${group.key}`} class="a11y-sr-only">
                 {group.title}
               </label>
@@ -91,6 +92,7 @@ const groups = [
       </consent-form-group>
     ))
   }
+  <button type="submit">[ Save preferences ]</button>
 </form>
 
 <script src="./ConsentForm.client.ts"></script>
@@ -114,7 +116,7 @@ const groups = [
     width: 100%;
     background: yellow;
   }
-  legend {
+  summary > span {
     font-weight: bold;
     padding: 10px;
     cursor: pointer;

--- a/src/components/ConsentForm/ConsentForm.client.ts
+++ b/src/components/ConsentForm/ConsentForm.client.ts
@@ -1,0 +1,52 @@
+class ConsentFormGroup extends HTMLElement {
+  #summaryCheckbox: HTMLInputElement;
+  #itemCheckboxes: HTMLInputElement[];
+  constructor() {
+    super();
+    this.#summaryCheckbox = this.querySelector('summary input[type="checkbox"]') as HTMLInputElement;
+    this.#itemCheckboxes = Array.from(this.querySelectorAll('li input[type="checkbox"]'));
+  }
+
+  connectedCallback() {
+    if (!this.#summaryCheckbox) {
+      console.warn('ConsentFormGroup: missing summary checkbox', this);
+      return;
+    }
+    this.#summaryCheckbox.addEventListener('change', this.#handleSummaryChange.bind(this));
+    this.#itemCheckboxes.forEach((checkbox) => {
+      checkbox.addEventListener('change', this.#handleItemChange.bind(this));
+    });
+    this.#summaryCheckbox.removeAttribute('hidden');
+  }
+
+  disconnectedCallback() {
+    this.#summaryCheckbox.removeEventListener('change', this.#handleSummaryChange.bind(this));
+    this.#itemCheckboxes.forEach((checkbox) => {
+      checkbox.removeEventListener('change', this.#handleItemChange.bind(this));
+    });
+  }
+
+  #handleSummaryChange() {
+    const checked = this.#summaryCheckbox.checked;
+    this.#itemCheckboxes.forEach((checkbox) => {
+      checkbox.checked = checked;
+    });
+  }
+
+  #handleItemChange() {
+    const allChecked = this.#itemCheckboxes.every((checkbox) => checkbox.checked);
+    const noneChecked = this.#itemCheckboxes.every((checkbox) => !checkbox.checked);
+    if (allChecked) {
+      this.#summaryCheckbox.checked = true;
+      this.#summaryCheckbox.indeterminate = false;
+    } else if (noneChecked) {
+      this.#summaryCheckbox.checked = false;
+      this.#summaryCheckbox.indeterminate = false;
+    } else /* partially checked */ {
+      this.#summaryCheckbox.checked = false;
+      this.#summaryCheckbox.indeterminate = true;
+    }
+  }
+}
+
+customElements.define('consent-form-group', ConsentFormGroup);

--- a/src/components/SwitchInput/README.md
+++ b/src/components/SwitchInput/README.md
@@ -1,0 +1,30 @@
+# Switch Input
+
+**A [switch](https://w3c.github.io/aria/#switch) functions similar to a checkbox but explicitly represents boolean on and off states.**
+
+## Notes
+
+Based on [web.dev: Building a switch component](https://web.dev/articles/building/a-switch-component).
+
+- Progressively enhances an `input[type="checkbox"]`.
+- Accessibility support using native checkbox states (`:checked`, `:indeterminate`), `role="switch"` and `reduced-motion` query.
+- Uses custom properties for styling, which you can overwrite when using the component (see [usage](#usage)).
+
+## Usage
+
+The switch input supports the same attributes as a checkbox input as that element is used under the hood.
+
+```astro
+---
+import SwitchInput from '@components/SwitchInput/SwitchInput.astro';
+---
+
+<label for="s1">Switch 1</label>
+<SwitchComponent name="s1" id="s1" />
+
+<label for="s2">Switch 2</label>
+<SwitchComponent name="s2" id="s2" checked={ true } />
+
+<label for="s3">Switch 3</label>
+<SwitchComponent name="s3" id="s3" style="--thumb-size: 2em;" />
+```

--- a/src/components/SwitchInput/SwitchInput.astro
+++ b/src/components/SwitchInput/SwitchInput.astro
@@ -1,7 +1,8 @@
 ---
 interface Props {
-  name: string;
-  checked?: boolean;
+  name?: string;
+  checked?: boolean | string;
+  [key: string]: unknown;
 }
 const { name, checked, ...props } = Astro.props;
 ---
@@ -9,8 +10,8 @@ const { name, checked, ...props } = Astro.props;
 <input
   {...props}
   name={name}
-  checked={checked}
-  role='checkbox'
+  checked={ checked ? 'checked' : undefined }
+  role='switch'
   type='checkbox'
   is='switch-input'
 />

--- a/src/components/SwitchInput/SwitchInput.astro
+++ b/src/components/SwitchInput/SwitchInput.astro
@@ -1,0 +1,114 @@
+---
+interface Props {
+  name: string;
+  checked?: boolean;
+}
+const { name, checked, ...props } = Astro.props;
+---
+
+<input
+  {...props}
+  name={name}
+  checked={checked}
+  role='checkbox'
+  type='checkbox'
+  is='switch-input'
+/>
+
+<script src='./SwitchInput.client.ts'></script>
+
+<style>
+  /* Based on https://web.dev/articles/building/a-switch-component */
+  /* Variables */
+  input {
+    --thumb-size: 1em;
+    --thumb: hsl(0 0% 100%);
+    --thumb-highlight: hsl(0 0% 0% / 25%);
+    --thumb-color: var(--thumb);
+    --thumb-color-highlight: var(--thumb-highlight);
+    --thumb-position: 0%;
+    --thumb-transition-duration: 0.2s;
+
+    --track-size: calc(var(--thumb-size) * 2);
+    --track-padding: 2px;
+    --track-inactive: hsl(80 0% 80%);
+    --track-active: currentColor;
+    --track-color-inactive: var(--track-inactive);
+    --track-color-active: var(--track-active);
+
+    --isLTR: 1;
+  }
+  input:dir(rtl) {
+    --isLTR: 0;
+  }
+  input:checked {
+    --thumb-position: calc(var(--track-size) - 100%);
+    --thumb-position: calc((var(--track-size) - 100%) * var(--isLTR));
+  }
+  input:indeterminate {
+    --thumb-position: calc((var(--track-size) / 2) - (var(--thumb-size) / 2));
+    --thumb-position: calc(
+      ((var(--track-size) / 2) - (var(--thumb-size) / 2)) * var(--isLTR)
+    );
+  }
+  @media (prefers-reduced-motion: reduce) {
+    input {
+      --thumb-transition-duration: 0s;
+    }
+  }
+  input:not(:disabled):hover::before {
+    --highlight-size: 5px;
+  }
+
+  /* Track */
+  input {
+    appearance: none;
+    cursor: pointer;
+    touch-action: pan-y;
+
+    background: var(--track-color-inactive);
+    border-radius: var(--track-size);
+
+    border: none;
+    outline-offset: 5px;
+    box-sizing: content-box;
+
+    inline-size: var(--track-size);
+    block-size: var(--thumb-size);
+    padding: var(--track-padding);
+
+    flex-shrink: 0;
+    display: grid;
+    align-items: center;
+    grid: [track] 1fr / [track] 1fr;
+  }
+  input:checked {
+    background: var(--track-color-active);
+    --thumb-position: calc((var(--track-size) - 100%) * var(--isLTR));
+  }
+  input:disabled {
+    cursor: not-allowed;
+    --thumb-color: transparent;
+  }
+
+  /* Thumb */
+  input::before {
+    content: '';
+    transform: translateX(var(--thumb-position));
+    grid-area: track;
+    inline-size: var(--thumb-size);
+    block-size: var(--thumb-size);
+    background: var(--thumb-color);
+    border-radius: 50%;
+    box-shadow: 0 0 0 var(--highlight-size) var(--thumb-color-highlight);
+  }
+  input:disabled::before {
+    cursor: not-allowed;
+    box-shadow: inset 0 0 0 2px hsl(0 0% 100% / 50%);
+  }
+  input::before {
+    transition:
+      transform var(--thumb-transition-duration) ease,
+      box-shadow 0.25s ease;
+  }
+</style>

--- a/src/components/SwitchInput/SwitchInput.client.ts
+++ b/src/components/SwitchInput/SwitchInput.client.ts
@@ -1,0 +1,98 @@
+/**
+ * Based on https://github.com/argyleink/gui-challenges/blob/main/switch/index.js
+ * Adapted to Custom Element with types.
+ * Unlike original, doesn't prevent event bubbling, so it plays nicely with other components.
+ */
+
+const getStyle = (element: HTMLElement, prop: string) => {
+  return parseInt(window.getComputedStyle(element).getPropertyValue(prop));
+};
+
+const getPseudoStyle = (element: HTMLElement, prop: string) => {
+  return parseInt(window.getComputedStyle(element, ':before').getPropertyValue(prop));
+};
+
+type Bounds = {
+  lower: number;
+  middle: number;
+  upper: number;
+};
+
+class SwitchInput extends HTMLInputElement {
+  #thumbsize: number = 0;
+  #padding: number = 0;
+  #bounds: Bounds = { lower: 0, middle: 0, upper: 0 };
+  #isDragging = false;
+  constructor() {
+    super();
+    this.#thumbsize = getPseudoStyle(this, 'width');
+    this.#padding = getStyle(this, 'padding-left') + getStyle(this, 'padding-right');
+    this.#bounds = {
+      lower: 0,
+      middle: (this.clientWidth - this.#padding) / 4,
+      upper: this.clientWidth - this.#thumbsize - this.#padding,
+    };
+  }
+
+  connectedCallback() {
+    this.addEventListener('pointerdown', this.#dragInit.bind(this));
+    this.addEventListener('pointerup', this.#dragEnd.bind(this));
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('pointerdown', this.#dragInit.bind(this));
+    this.removeEventListener('pointerup', this.#dragEnd.bind(this));
+  }
+
+  #dragInit() {
+    if (this.disabled) return;
+    this.#isDragging = true;
+    this.addEventListener('pointermove', this.#dragging.bind(this));
+    this.style.setProperty('--thumb-transition-duration', '0s');
+    window.addEventListener('pointerup', this.#dragEnd.bind(this));
+  }
+
+  #dragging(event: PointerEvent) {
+    if (!this.#isDragging) return;
+    const directionality = getStyle(this, '--isLTR');
+    const trackPosition = (directionality === -1)
+      ? (this.clientWidth * -1) + this.#thumbsize + this.#padding
+      : 0;
+    const pointerPosition = 
+      Math.min(
+        Math.max(
+          event.offsetX - this.#thumbsize / 2,
+          this.#bounds.lower
+        ),
+        this.#bounds.upper
+      );
+    const thumbPosition = trackPosition + pointerPosition;
+    this.style.setProperty('--thumb-position', `${thumbPosition}px`);
+  }
+
+  #dragEnd() {
+    if (!this.#isDragging) return;
+  
+    this.#isDragging = false;
+    this.checked = !this.#determineChecked();
+    this.indeterminate = false;
+
+    this.style.removeProperty('--thumb-transition-duration');
+    this.style.removeProperty('--thumb-position');
+  
+    this.removeEventListener('pointermove', this.#dragging.bind(this));
+    window.removeEventListener('pointerup', this.#dragEnd.bind(this));
+  }
+
+  #determineChecked() {
+    let thumbPosition = Math.abs(parseInt(this.style.getPropertyValue('--thumb-position')));
+    if (!thumbPosition) {
+      thumbPosition = this.checked
+        ? this.#bounds.lower
+        : this.#bounds.upper;
+    }
+    return thumbPosition >= this.#bounds.middle;
+  }
+}
+
+customElements.define('switch-input', SwitchInput, { extends: 'input' });

--- a/src/pages/consent.astro
+++ b/src/pages/consent.astro
@@ -1,0 +1,5 @@
+---
+import ConsentForm from '@components/ConsentForm/ConsentForm.astro';
+---
+
+<ConsentForm />


### PR DESCRIPTION
# Changes

- Adds Consent Form component with grouped consent items. Each group is enhanced with a summary checkbox, which controls and reflects the combined state of the item checkboxes.
- Adds Switch Input component enhancing `input[type="checkbox"]` to an accessible switch.
- [ ] Configurable consent groups and items
- [ ] Consent Manager as (nano)store
- [ ] Uses timestamp as values, so future policy changes can request new consent

WIP: https://feat-consent-form.head-start.pages.dev/consent/

# Associated issue

Resolves #49.

# How to test

...

<!-- example:
1. Open preview link
2. Navigate to ...
3. Tap on ...
4. Verify that ...
5. Etc ...
-->

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [ ] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
