### PR TITLE
feature: Video Block

### DIFF
--- a/config/datocms/migrations/1706472108_videoBlock.ts
+++ b/config/datocms/migrations/1706472108_videoBlock.ts
@@ -1,0 +1,293 @@
+import { Client } from '@datocms/cli/lib/cma-client-node';
+
+export default async function (client: Client) {
+  console.log('Create new models/block models');
+
+  console.log('Create block model "\uD83C\uDFAC Video Block" (`video_block`)');
+  await client.itemTypes.create(
+    {
+      // @ts-expect-error next-line DatoCMS auto-generated
+      id: 'QYfZyBzIRWKxA1MinIR0aQ',
+      name: '\uD83C\uDFAC Video Block',
+      api_key: 'video_block',
+      modular_block: true,
+      inverse_relationships_enabled: false,
+    },
+    { skip_menu_item_creation: true }
+  );
+
+  console.log(
+    'Create model "\uD83D\uDD21 Video Text Track" (`video_text_track`)'
+  );
+  await client.itemTypes.create(
+    {
+      // @ts-expect-error next-line DatoCMS auto-generated
+      id: 'Us90isT5SgeXHuetcEj8eA',
+      name: '\uD83D\uDD21 Video Text Track',
+      api_key: 'video_text_track',
+      collection_appearance: 'table',
+      inverse_relationships_enabled: false,
+    },
+    { skip_menu_item_creation: true }
+  );
+
+  console.log('Creating new fields/fieldsets');
+
+  console.log(
+    'Create Single asset field "Video" (`video_asset`) in block model "\uD83C\uDFAC Video Block" (`video_block`)'
+  );
+  await client.fields.create('QYfZyBzIRWKxA1MinIR0aQ', {
+    // @ts-expect-error next-line DatoCMS auto-generated
+    id: 'KdXhYelkQdaepb_wpK7yuw',
+    label: 'Video',
+    field_type: 'file',
+    api_key: 'video_asset',
+    validators: { required: {} },
+    appearance: { addons: [], editor: 'file', parameters: {} },
+    default_value: null,
+  });
+
+  console.log(
+    'Create Single-line string field "Title" (`title`) in block model "\uD83C\uDFAC Video Block" (`video_block`)'
+  );
+  await client.fields.create('QYfZyBzIRWKxA1MinIR0aQ', {
+    // @ts-expect-error next-line DatoCMS auto-generated
+    id: 'CYYGKtnXSkiSCTYMrOI3Yg',
+    label: 'Title',
+    field_type: 'string',
+    api_key: 'title',
+    hint: 'Optional title. By default the title from the selected video is used.',
+    appearance: {
+      addons: [],
+      editor: 'single_line',
+      parameters: { heading: false },
+    },
+    default_value: '',
+  });
+
+  console.log(
+    'Create Boolean field "Autoplay" (`autoplay`) in block model "\uD83C\uDFAC Video Block" (`video_block`)'
+  );
+  await client.fields.create('QYfZyBzIRWKxA1MinIR0aQ', {
+    // @ts-expect-error next-line DatoCMS auto-generated
+    id: 'SEULcq3NS06_pDVrsHxiUA',
+    label: 'Autoplay',
+    field_type: 'boolean',
+    api_key: 'autoplay',
+    hint: 'Note: video will only autoplay if device supports it and user has consented to 3rd party content.',
+    appearance: { addons: [], editor: 'boolean', parameters: {} },
+    default_value: null,
+  });
+
+  console.log(
+    'Create Boolean field "Mute" (`mute`) in block model "\uD83C\uDFAC Video Block" (`video_block`)'
+  );
+  await client.fields.create('QYfZyBzIRWKxA1MinIR0aQ', {
+    // @ts-expect-error next-line DatoCMS auto-generated
+    id: 'YaS-9DSqS3umFlirmXcOkw',
+    label: 'Mute',
+    field_type: 'boolean',
+    api_key: 'mute',
+    appearance: { addons: [], editor: 'boolean', parameters: {} },
+    default_value: null,
+  });
+
+  console.log(
+    'Create Boolean field "Loop" (`loop`) in block model "\uD83C\uDFAC Video Block" (`video_block`)'
+  );
+  await client.fields.create('QYfZyBzIRWKxA1MinIR0aQ', {
+    // @ts-expect-error next-line DatoCMS auto-generated
+    id: 'AsETx2yITvOK2QKbu8bYRw',
+    label: 'Loop',
+    field_type: 'boolean',
+    api_key: 'loop',
+    appearance: { addons: [], editor: 'boolean', parameters: {} },
+    default_value: null,
+  });
+
+  console.log(
+    'Create Multiple links field "Tracks" (`tracks`) in block model "\uD83C\uDFAC Video Block" (`video_block`)'
+  );
+  await client.fields.create('QYfZyBzIRWKxA1MinIR0aQ', {
+    // @ts-expect-error next-line DatoCMS auto-generated
+    id: 'WVz9yVpWSymoFxO4oKzzeA',
+    label: 'Tracks',
+    field_type: 'links',
+    api_key: 'tracks',
+    hint: 'For accessibility, videos should provide both captions and transcripts that accurately describe its content. Captions allow people who are experiencing hearing loss to understand a video\'s audio content as the video is being played, while transcripts allow people who need additional time to be able to review audio content at a pace and format that is comfortable for them.',
+    validators: {
+      items_item_type: {
+        on_publish_with_unpublished_references_strategy: 'fail',
+        on_reference_unpublish_strategy: 'delete_references',
+        on_reference_delete_strategy: 'delete_references',
+        item_types: ['Us90isT5SgeXHuetcEj8eA'],
+      },
+    },
+    appearance: { addons: [], editor: 'links_embed', parameters: {} },
+    default_value: null,
+  });
+
+  console.log(
+    'Create Single-line string field "Title" (`title`) in model "\uD83D\uDD21 Video Text Track" (`video_text_track`)'
+  );
+  await client.fields.create('Us90isT5SgeXHuetcEj8eA', {
+    // @ts-expect-error next-line DatoCMS auto-generated
+    id: 'GzfEVsO6QnOu2KRUaPhc5Q',
+    label: 'Title',
+    field_type: 'string',
+    api_key: 'title',
+    hint: 'A user-readable title of the text track which is used by the browser when listing available text tracks. Defaults to selected language name (English, Deutsch, etc) when empty.',
+    appearance: {
+      addons: [],
+      editor: 'single_line',
+      parameters: { heading: false },
+    },
+    default_value: '',
+  });
+
+  console.log(
+    'Create Single-line string field "Locale" (`locale`) in model "\uD83D\uDD21 Video Text Track" (`video_text_track`)'
+  );
+  await client.fields.create('Us90isT5SgeXHuetcEj8eA', {
+    // @ts-expect-error next-line DatoCMS auto-generated
+    id: 'AD-nA46KQc2wL8978d6asg',
+    label: 'Locale',
+    field_type: 'string',
+    api_key: 'locale',
+    validators: { required: {} },
+    appearance: {
+      addons: [],
+      editor: 'string_select',
+      parameters: {
+        options: [
+          { hint: '', label: 'Deutsch', value: 'de' },
+          { hint: '', label: 'English', value: 'en' },
+          { hint: '', label: 'Espa\u00F1ol', value: 'es' },
+          { hint: '', label: 'Fran\u00E7ais', value: 'fr' },
+          { hint: '', label: 'Italiano', value: 'it' },
+          { hint: '', label: 'Nederlands', value: 'nl' },
+        ],
+      },
+    },
+    default_value: '',
+  });
+
+  console.log(
+    'Create Single-line string field "Kind" (`kind`) in model "\uD83D\uDD21 Video Text Track" (`video_text_track`)'
+  );
+  await client.fields.create('Us90isT5SgeXHuetcEj8eA', {
+    // @ts-expect-error next-line DatoCMS auto-generated
+    id: 'F7QOFgNLStmPAdNlSn7uuQ',
+    label: 'Kind',
+    field_type: 'string',
+    api_key: 'kind',
+    hint: 'How the text track is meant to be used.',
+    validators: {
+      required: {},
+      enum: {
+        values: [
+          'subtitles',
+          'captions',
+          'descriptions',
+          'chapters',
+          'metadata',
+        ],
+      },
+    },
+    appearance: {
+      addons: [],
+      editor: 'single_line',
+      parameters: { heading: false },
+    },
+    default_value: 'subtitles',
+  });
+
+  console.log(
+    'Create Single asset field "File" (`file`) in model "\uD83D\uDD21 Video Text Track" (`video_text_track`)'
+  );
+  await client.fields.create('Us90isT5SgeXHuetcEj8eA', {
+    // @ts-expect-error next-line DatoCMS auto-generated
+    id: 'XNFlO-LWQJiMDd5r44PaKw',
+    label: 'File',
+    field_type: 'file',
+    api_key: 'file',
+    validators: { required: {}, extension: { extensions: ['vtt'] } },
+    appearance: { addons: [], editor: 'file', parameters: {} },
+    default_value: null,
+  });
+
+  console.log('Update existing fields/fieldsets');
+
+  console.log(
+    'Update Modular content field "Body" (`body_blocks`) in model "Home" (`home`)'
+  );
+  await client.fields.update('pUj2PObgTyC-8X4lvZLMBA', {
+    validators: {
+      rich_text_blocks: {
+        item_types: [
+          'BRbU6VwTRgmG5SbwUs0rBg',
+          'PAk40zGjQJCcDXXPgygUrA',
+          'QYfZyBzIRWKxA1MinIR0aQ',
+          'VZvVfu52RZK81WG0Dxp-FQ',
+          'V80liDVtRC-UYgd3Sm-dXg',
+          'ZdBokLsWRgKKjHrKeJzdpw',
+          'gezG9nO7SfaiWcWnp-HNqw',
+          '0SxYNS2CR1it_5LHYWuEQg',
+        ],
+      },
+    },
+  });
+
+  console.log(
+    'Update Modular content field "Body" (`body_blocks`) in model "Page" (`page`)'
+  );
+  await client.fields.update('Q-z1nyMsQtC8Sr6w6J2oGw', {
+    validators: {
+      rich_text_blocks: {
+        item_types: [
+          'BRbU6VwTRgmG5SbwUs0rBg',
+          'PAk40zGjQJCcDXXPgygUrA',
+          'QYfZyBzIRWKxA1MinIR0aQ',
+          'VZvVfu52RZK81WG0Dxp-FQ',
+          'V80liDVtRC-UYgd3Sm-dXg',
+          'ZdBokLsWRgKKjHrKeJzdpw',
+          'gezG9nO7SfaiWcWnp-HNqw',
+          '0SxYNS2CR1it_5LHYWuEQg',
+        ],
+      },
+    },
+  });
+
+  console.log(
+    'Update Structured text field "Text" (`text`) in block model "Text Block" (`text_block`)'
+  );
+  await client.fields.update('NtVXfZ6gTL2sKNffNeUf5Q', {
+    validators: {
+      required: {},
+      structured_text_blocks: {
+        item_types: [
+          'QYfZyBzIRWKxA1MinIR0aQ',
+          'ZdBokLsWRgKKjHrKeJzdpw',
+          'gezG9nO7SfaiWcWnp-HNqw',
+          '0SxYNS2CR1it_5LHYWuEQg',
+        ],
+      },
+      structured_text_links: {
+        on_publish_with_unpublished_references_strategy: 'fail',
+        on_reference_unpublish_strategy: 'delete_references',
+        on_reference_delete_strategy: 'delete_references',
+        item_types: ['WywlzYXpSVWFQIeeNk3iMw'],
+      },
+    },
+  });
+
+  console.log('Finalize models/block models');
+
+  console.log(
+    'Update model "\uD83D\uDD21 Video Text Track" (`video_text_track`)'
+  );
+  await client.itemTypes.update('Us90isT5SgeXHuetcEj8eA', {
+    title_field: { id: 'AD-nA46KQc2wL8978d6asg', type: 'field' },
+    image_preview_field: { id: 'XNFlO-LWQJiMDd5r44PaKw', type: 'field' },
+  });
+}

--- a/datocms-environment.ts
+++ b/datocms-environment.ts
@@ -3,5 +3,5 @@
  * @see docs/getting-started.md on how to use this file
  * @see docs/decision-log/2023-10-24-datocms-env-file.md on why file is preferred over env vars
  */
-export const datocmsEnvironment = 'embed-block';
+export const datocmsEnvironment = 'video-block';
 export const datocmsBuildTriggerId = '30535';

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "datocms-structured-text-utils": "^2.0.4",
         "get-video-id": "^3.6.5",
         "globby": "^13.2.2",
+        "hls.js": "^1.5.2",
         "html-validate": "^8.7.4",
         "jiti": "^1.20.0",
         "nanostores": "^0.9.5",
@@ -9689,6 +9690,11 @@
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.2.tgz",
+      "integrity": "sha512-MJtx9GbfO1We1N6Zx5JbxdIAGLQWKPss56YzkR45GIdVcz+jBQVbLBZnsANpQpECvRBWZUcg9opEDo1biG/qVA=="
     },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "datocms-structured-text-utils": "^2.0.4",
     "get-video-id": "^3.6.5",
     "globby": "^13.2.2",
+    "hls.js": "^1.5.2",
     "html-validate": "^8.7.4",
     "jiti": "^1.20.0",
     "nanostores": "^0.9.5",

--- a/src/blocks/Blocks.astro
+++ b/src/blocks/Blocks.astro
@@ -6,6 +6,7 @@ import PagePartialBlock from './PagePartialBlock/PagePartialBlock.astro';
 import TableBlock from './TableBlock/TableBlock.astro';
 import TextBlock from './TextBlock/TextBlock.astro';
 import TextImageBlock from './TextImageBlock/TextImageBlock.astro';
+import VideoBlock from './VideoBlock/VideoBlock.astro';
 import VideoEmbedBlock from './VideoEmbedBlock/VideoEmbedBlock.astro';
 
 const blocksByTypename = {
@@ -15,6 +16,7 @@ const blocksByTypename = {
   TableBlockRecord: TableBlock,
   TextBlockRecord: TextBlock,
   TextImageBlockRecord: TextImageBlock,
+  VideoBlockRecord: VideoBlock,
   VideoEmbedBlockRecord: VideoEmbedBlock,
 };
 

--- a/src/blocks/Blocks.d.ts
+++ b/src/blocks/Blocks.d.ts
@@ -5,6 +5,7 @@ import {
   TableBlockFragment,
   TextBlockFragment,
   TextImageBlockFragment,
+  VideoBlockFragment,
   VideoEmbedBlockFragment,
 } from '@lib/types/datocms';
 
@@ -15,4 +16,5 @@ export type AnyBlock =
   | TableBlockFragment
   | TextBlockFragment
   | TextImageBlockFragment
+  | VideoBlockFragment
   | VideoEmbedBlockFragment;

--- a/src/blocks/EmbedBlock/embeds/Default.client.ts
+++ b/src/blocks/EmbedBlock/embeds/Default.client.ts
@@ -1,4 +1,4 @@
-const enhanceIntersectedDefaultEmbeds = (entries: IntersectionObserverEntry[]) => {
+const enhanceIntersectedEmbeds = (entries: IntersectionObserverEntry[]) => {
   entries.forEach((entry) => {
     if (entry.isIntersecting && entry.target instanceof DefaultEmbed) {
       entry.target.enhance();
@@ -6,8 +6,8 @@ const enhanceIntersectedDefaultEmbeds = (entries: IntersectionObserverEntry[]) =
   });
 };
 
-const defaultEmbedObserver = new IntersectionObserver(
-  enhanceIntersectedDefaultEmbeds,
+const observer = new IntersectionObserver(
+  enhanceIntersectedEmbeds,
   { rootMargin: '100px' }
 );
 
@@ -25,11 +25,11 @@ class DefaultEmbed extends HTMLElement {
   }
 
   connectedCallback() {
-    defaultEmbedObserver.observe(this);
+    observer.observe(this);
   }
 
   enhance() {
-    defaultEmbedObserver.unobserve(this);
+    observer.unobserve(this);
 
     if (this.#isEnhanced) {
       return;

--- a/src/blocks/EmbedBlock/embeds/Default.client.ts
+++ b/src/blocks/EmbedBlock/embeds/Default.client.ts
@@ -1,4 +1,4 @@
-const enhanceIntersectedEmbeds = (entries: IntersectionObserverEntry[]) => {
+const enhanceIntersectedDefaultEmbeds = (entries: IntersectionObserverEntry[]) => {
   entries.forEach((entry) => {
     if (entry.isIntersecting && entry.target instanceof DefaultEmbed) {
       entry.target.enhance();
@@ -6,8 +6,8 @@ const enhanceIntersectedEmbeds = (entries: IntersectionObserverEntry[]) => {
   });
 };
 
-const observer = new IntersectionObserver(
-  enhanceIntersectedEmbeds,
+const defaultEmbedObserver = new IntersectionObserver(
+  enhanceIntersectedDefaultEmbeds,
   { rootMargin: '100px' }
 );
 
@@ -25,11 +25,11 @@ class DefaultEmbed extends HTMLElement {
   }
 
   connectedCallback() {
-    observer.observe(this);
+    defaultEmbedObserver.observe(this);
   }
 
   enhance() {
-    observer.unobserve(this);
+    defaultEmbedObserver.unobserve(this);
 
     if (this.#isEnhanced) {
       return;

--- a/src/blocks/TextBlock/TextBlock.fragment.graphql
+++ b/src/blocks/TextBlock/TextBlock.fragment.graphql
@@ -1,6 +1,7 @@
 #import '@blocks/ImageBlock/ImageBlock.fragment.graphql'
 #import '@blocks/InternalLink/InternalLink.fragment.graphql'
 #import '@blocks/TableBlock/TableBlock.fragment.graphql'
+#import '@blocks/VideoBlock/VideoBlock.fragment.graphql'
 #import '@blocks/VideoEmbedBlock/VideoEmbedBlock.fragment.graphql'
 
 fragment TextBlock on TextBlockRecord {
@@ -12,6 +13,9 @@ fragment TextBlock on TextBlockRecord {
       }
       ... on TableBlockRecord {
         ...TableBlock
+      }
+      ... on VideoBlockRecord {
+        ...VideoBlock
       }
       ... on VideoEmbedBlockRecord {
         ...VideoEmbedBlock

--- a/src/blocks/VideoBlock/README.md
+++ b/src/blocks/VideoBlock/README.md
@@ -1,0 +1,12 @@
+# VideoBlock
+
+<!-- summarize functionality, and how it relates to a DatoCMS model:
+**...**
+-->
+
+## Features
+
+<!-- list its main features:
+- ...
+- ...
+-->

--- a/src/blocks/VideoBlock/README.md
+++ b/src/blocks/VideoBlock/README.md
@@ -1,12 +1,15 @@
 # VideoBlock
 
-<!-- summarize functionality, and how it relates to a DatoCMS model:
-**...**
--->
+**Renders a video uploaded in DatoCMS with a cover image, caption, support for subtitles and options to autoplay, mute and loop.**
 
 ## Features
 
-<!-- list its main features:
-- ...
-- ...
--->
+- Privacy first alternative to [Video Embed Block](../VideoEmbedBlock/), as video uploaded in DatoCMS is served without tracking (no consent required).
+- Supports video streaming with adaptive bitrate (using HLS) for best UX and performance.
+- Fallback to mp4 video when streaming is not available.
+- Fallback to video download link when HTML video element is not supported.
+- Supports subtitle tracks for enhanced accessibility, automatically selecting default locale when available.
+- Supports figcaption defaulting to external video's title and optional custom title override.
+- Supports autoplay, mute and loop.
+- Autoplay is only triggered if no reduced motion is preferred (for a11y) and save data mode is off.
+- Conditionally loads video and streaming package (`hls.js`) on click or when in view in case autoplay is enabled.

--- a/src/blocks/VideoBlock/VideoBlock.astro
+++ b/src/blocks/VideoBlock/VideoBlock.astro
@@ -1,5 +1,6 @@
 ---
 import type { UploadVideoField, VideoBlockFragment } from '@lib/types/datocms';
+import { getLocale, getLocaleName } from '@lib/i18n';
 
 interface Props {
   block: VideoBlockFragment;
@@ -8,28 +9,41 @@ const { block } = Astro.props;
 const { alt, width, height } = block.videoAsset;
 const video = block.videoAsset.video as UploadVideoField;
 const aspectRatio = width && height ? width / height : null;
+const activeLocale = getLocale();
 ---
 
-<figure>
-  <video
-    poster={video.thumbnailUrl}
-    controls
-    autoplay={block.autoplay ? 'true' : 'false'}
-    loop={block.loop ? 'true' : 'false'}
-    muted={block.mute ? 'true' : 'false'}
-    width={width}
-    height={height}
-    preload='none'
-    style={{ aspectRatio }}
-  >
-    <source src={video.mp4Url} type='video/mp4' />
-    {alt}
-  </video>
+<video-block data-autoplay={ block.autoplay ? 'true' : 'false' }>
+  <figure>
+    <video
+      poster={video.thumbnailUrl}
+      controls
+      crossorigin="anonymous"
+      autoplay={block.autoplay ? 'true' : null}
+      loop={block.loop ? 'true' : null}
+      muted={block.mute ? 'true' : null}
+      width={width}
+      height={height}
+      preload='none'
+      style={{ aspectRatio }}
+    >
+      <source src={video.mp4Url} type='video/mp4' />
+      { block.tracks.map(track => (
+        <track
+          kind={track.kind}
+          label={track.title || getLocaleName(track.locale) }
+          src={track.file.url}
+          srclang={track.locale}
+          default={track.locale === activeLocale}
+        />
+      )) }
+      {alt}
+    </video>
 
-  {block.title && <figcaption>{block.title}</figcaption>}
-</figure>
+    {block.title && <figcaption>{block.title}</figcaption>}
+  </figure>
+</video-block>
 
-<pre><code>VideoBlock: {JSON.stringify(block, null, 2)}</code></pre>
+<script src="./VideoBlock.client.ts"></script>
 
 <style>
   video {

--- a/src/blocks/VideoBlock/VideoBlock.astro
+++ b/src/blocks/VideoBlock/VideoBlock.astro
@@ -35,6 +35,7 @@ const videoAttributes = {
       */ }
     <div style={{ aspectRatio }}>
       <video { ...videoAttributes } data-video>
+        <source src={video.streamingUrl} type='application/vnd.apple.mpegurl' />
         <VideoTextTracks tracks={ block.tracks as VideoTextTrackRecord[] } />
         { alt }
       </video>

--- a/src/blocks/VideoBlock/VideoBlock.astro
+++ b/src/blocks/VideoBlock/VideoBlock.astro
@@ -1,6 +1,6 @@
 ---
-import type { UploadVideoField, VideoBlockFragment } from '@lib/types/datocms';
-import { getLocale, getLocaleName } from '@lib/i18n';
+import type { UploadVideoField, VideoBlockFragment, VideoTextTrackRecord } from '@lib/types/datocms';
+import VideoTextTracks from './VideoTextTracks.astro';
 
 interface Props {
   block: VideoBlockFragment;
@@ -9,7 +9,17 @@ const { block } = Astro.props;
 const { alt, width, height } = block.videoAsset;
 const video = block.videoAsset.video as UploadVideoField;
 const aspectRatio = width && height ? width / height : null;
-const activeLocale = getLocale();
+const videoAttributes = {
+  poster: video.thumbnailUrl,
+  controls: true,
+  crossorigin: 'anonymous',
+  loop: block.loop ? 'true' : null,
+  muted: block.mute ? 'true' : null,
+  width,
+  height,
+  preload: 'none',
+  style: { aspectRatio },
+};
 ---
 
 <video-block
@@ -18,35 +28,26 @@ const activeLocale = getLocale();
   data-streaming-url={ video.streamingUrl }
 >
   <figure>
-    <video
-      poster={video.thumbnailUrl}
-      controls
-      crossorigin="anonymous"
-      loop={block.loop ? 'true' : null}
-      muted={block.mute ? 'true' : null}
-      width={width}
-      height={height}
-      preload='none'
-      style={{ aspectRatio }}
-    >
-      { block.tracks.map(track => (
-        <track
-          kind={track.kind}
-          label={track.title || getLocaleName(track.locale) }
-          src={track.file.url}
-          srclang={track.locale}
-          default={track.locale === activeLocale}
-        />
-      )) }
-      <!-- [html-validate-disable-next element-permitted-content -- noscript is allowed in any element that includes phrasing content, including video tag. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript and https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content ] -->
+    { /* We use 2 video elements: 
+      - The first is enhanced in the client-side script to use streaming with adaptive bitrate.
+      - The second is fallback native video element that works without JS or custom elmenet support.
+      As a JS check is needed for the first video to appear, it's wrapped in a div to reserve space for it.
+      */ }
+    <div style={{ aspectRatio }}>
+      <video { ...videoAttributes } data-video>
+        <VideoTextTracks tracks={ block.tracks as VideoTextTrackRecord[] } />
+        { alt }
+      </video>
       <noscript>
-        <source src={video.streamingUrl} type='application/vnd.apple.mpegurl' />
-        <source src={video.streamingUrl} type='application/x-mpegURL' />
-        <source src={video.mp4Url} type='video/mp4' />
+        <video { ...videoAttributes }>
+          <VideoTextTracks tracks={ block.tracks as VideoTextTrackRecord[] } />
+          <source src={video.streamingUrl} type='application/vnd.apple.mpegurl' />
+          <source src={video.streamingUrl} type='application/x-mpegURL' />
+          <source src={video.mp4Url} type='video/mp4' />
+          { alt }
+        </video>
       </noscript>
-      { alt }
-    </video>
-
+    </div>
     {block.title && <figcaption>{block.title}</figcaption>}
   </figure>
 </video-block>
@@ -54,10 +55,26 @@ const activeLocale = getLocale();
 <script src="./VideoBlock.client.ts"></script>
 
 <style>
+  /* functional styling */
+  figure {
+    position: relative;
+  }
+  video-block [data-video] {
+    display: none;
+  }
+  video-block:defined [data-video] {
+    display: block;
+  }
+
   video {
     display: block;
     max-width: 100%;
     height: auto;
     object-fit: contain;
+  }
+
+  /* basic styling, can be removed */
+  figcaption {
+    text-align: center;
   }
 </style>

--- a/src/blocks/VideoBlock/VideoBlock.astro
+++ b/src/blocks/VideoBlock/VideoBlock.astro
@@ -40,10 +40,10 @@ const videoAttributes = {
       </video>
       <noscript>
         <video { ...videoAttributes }>
-          <VideoTextTracks tracks={ block.tracks as VideoTextTrackRecord[] } />
           <source src={video.streamingUrl} type='application/vnd.apple.mpegurl' />
           <source src={video.streamingUrl} type='application/x-mpegURL' />
           <source src={video.mp4Url} type='video/mp4' />
+          <VideoTextTracks tracks={ block.tracks as VideoTextTrackRecord[] } />
           { alt }
         </video>
       </noscript>

--- a/src/blocks/VideoBlock/VideoBlock.astro
+++ b/src/blocks/VideoBlock/VideoBlock.astro
@@ -38,7 +38,7 @@ const activeLocale = getLocale();
           default={track.locale === activeLocale}
         />
       )) }
-      <!-- [html-validate-disable-next element-permitted-content -- noscript is allowed in any element that includes phrasing content, including video tag. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript and https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content -->
+      <!-- [html-validate-disable-next element-permitted-content -- noscript is allowed in any element that includes phrasing content, including video tag. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript and https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content ] -->
       <noscript>
         <source src={video.streamingUrl} type='application/vnd.apple.mpegurl' />
         <source src={video.streamingUrl} type='application/x-mpegURL' />

--- a/src/blocks/VideoBlock/VideoBlock.astro
+++ b/src/blocks/VideoBlock/VideoBlock.astro
@@ -38,7 +38,7 @@ const videoAttributes = {
       <video { ...videoAttributes } data-video>
         <source src={video.streamingUrl} type='application/vnd.apple.mpegurl' />
         <VideoTextTracks tracks={ block.tracks as VideoTextTrackRecord[] } />
-        <VideoFallback alt={ alt } video={ video } />
+        <VideoFallback alt={ alt } title={ block.title } video={ video } />
       </video>
       <noscript>
         <video { ...videoAttributes }>
@@ -46,7 +46,7 @@ const videoAttributes = {
           <source src={video.streamingUrl} type='application/x-mpegURL' />
           <source src={video.mp4Url} type='video/mp4' />
           <VideoTextTracks tracks={ block.tracks as VideoTextTrackRecord[] } />
-          <VideoFallback alt={ alt } video={ video } />
+          <VideoFallback alt={ alt } title={ block.title } video={ video } />
         </video>
       </noscript>
     </div>

--- a/src/blocks/VideoBlock/VideoBlock.astro
+++ b/src/blocks/VideoBlock/VideoBlock.astro
@@ -8,6 +8,7 @@ interface Props {
 }
 const { block } = Astro.props;
 const { alt, width, height } = block.videoAsset;
+const title = block.videoAsset.title || block.title;
 const video = block.videoAsset.video as UploadVideoField;
 const aspectRatio = width && height ? width / height : null;
 const videoAttributes = {
@@ -38,7 +39,7 @@ const videoAttributes = {
       <video { ...videoAttributes } data-video>
         <source src={video.streamingUrl} type='application/vnd.apple.mpegurl' />
         <VideoTextTracks tracks={ block.tracks as VideoTextTrackRecord[] } />
-        <VideoFallback alt={ alt } title={ block.title } video={ video } />
+        <VideoFallback alt={ alt } title={ title } video={ video } />
       </video>
       <noscript>
         <video { ...videoAttributes }>
@@ -46,11 +47,11 @@ const videoAttributes = {
           <source src={video.streamingUrl} type='application/x-mpegURL' />
           <source src={video.mp4Url} type='video/mp4' />
           <VideoTextTracks tracks={ block.tracks as VideoTextTrackRecord[] } />
-          <VideoFallback alt={ alt } title={ block.title } video={ video } />
+          <VideoFallback alt={ alt } title={ title } video={ video } />
         </video>
       </noscript>
     </div>
-    {block.title && <figcaption>{block.title}</figcaption>}
+    { title && <figcaption>{ title }</figcaption>}
   </figure>
 </video-block>
 

--- a/src/blocks/VideoBlock/VideoBlock.astro
+++ b/src/blocks/VideoBlock/VideoBlock.astro
@@ -29,11 +29,6 @@ const activeLocale = getLocale();
       preload='none'
       style={{ aspectRatio }}
     >
-      <noscript>
-        <source src={video.streamingUrl} type='application/vnd.apple.mpegurl' />
-        <source src={video.streamingUrl} type='application/x-mpegURL' />
-        <source src={video.mp4Url} type='video/mp4' />
-      </noscript>
       { block.tracks.map(track => (
         <track
           kind={track.kind}
@@ -43,7 +38,13 @@ const activeLocale = getLocale();
           default={track.locale === activeLocale}
         />
       )) }
-      {alt}
+      <!-- [html-validate-disable-next element-permitted-content -- noscript is allowed in any element that includes phrasing content, including video tag. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript and https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content -->
+      <noscript>
+        <source src={video.streamingUrl} type='application/vnd.apple.mpegurl' />
+        <source src={video.streamingUrl} type='application/x-mpegURL' />
+        <source src={video.mp4Url} type='video/mp4' />
+      </noscript>
+      { alt }
     </video>
 
     {block.title && <figcaption>{block.title}</figcaption>}

--- a/src/blocks/VideoBlock/VideoBlock.astro
+++ b/src/blocks/VideoBlock/VideoBlock.astro
@@ -1,5 +1,6 @@
 ---
 import type { UploadVideoField, VideoBlockFragment, VideoTextTrackRecord } from '@lib/types/datocms';
+import VideoFallback from './VideoFallback.astro';
 import VideoTextTracks from './VideoTextTracks.astro';
 
 interface Props {
@@ -37,7 +38,7 @@ const videoAttributes = {
       <video { ...videoAttributes } data-video>
         <source src={video.streamingUrl} type='application/vnd.apple.mpegurl' />
         <VideoTextTracks tracks={ block.tracks as VideoTextTrackRecord[] } />
-        { alt }
+        <VideoFallback alt={ alt } video={ video } />
       </video>
       <noscript>
         <video { ...videoAttributes }>
@@ -45,7 +46,7 @@ const videoAttributes = {
           <source src={video.streamingUrl} type='application/x-mpegURL' />
           <source src={video.mp4Url} type='video/mp4' />
           <VideoTextTracks tracks={ block.tracks as VideoTextTrackRecord[] } />
-          { alt }
+          <VideoFallback alt={ alt } video={ video } />
         </video>
       </noscript>
     </div>

--- a/src/blocks/VideoBlock/VideoBlock.astro
+++ b/src/blocks/VideoBlock/VideoBlock.astro
@@ -12,7 +12,11 @@ const aspectRatio = width && height ? width / height : null;
 const activeLocale = getLocale();
 ---
 
-<video-block data-autoplay={ block.autoplay ? 'true' : 'false' }>
+<video-block
+  data-autoplay={ block.autoplay ? 'true' : 'false' }
+  data-mp4-url={ video.mp4Url }
+  data-streaming-url={ video.streamingUrl }
+>
   <figure>
     <video
       poster={video.thumbnailUrl}
@@ -25,9 +29,11 @@ const activeLocale = getLocale();
       preload='none'
       style={{ aspectRatio }}
     >
-      <source src={video.streamingUrl} type='application/vnd.apple.mpegurl' />
-      <source src={video.streamingUrl} type='application/x-mpegURL' />
-      <source src={video.mp4Url} type='video/mp4' />
+      <noscript>
+        <source src={video.streamingUrl} type='application/vnd.apple.mpegurl' />
+        <source src={video.streamingUrl} type='application/x-mpegURL' />
+        <source src={video.mp4Url} type='video/mp4' />
+      </noscript>
       { block.tracks.map(track => (
         <track
           kind={track.kind}

--- a/src/blocks/VideoBlock/VideoBlock.astro
+++ b/src/blocks/VideoBlock/VideoBlock.astro
@@ -18,7 +18,6 @@ const activeLocale = getLocale();
       poster={video.thumbnailUrl}
       controls
       crossorigin="anonymous"
-      autoplay={block.autoplay ? 'true' : null}
       loop={block.loop ? 'true' : null}
       muted={block.mute ? 'true' : null}
       width={width}

--- a/src/blocks/VideoBlock/VideoBlock.astro
+++ b/src/blocks/VideoBlock/VideoBlock.astro
@@ -25,6 +25,8 @@ const activeLocale = getLocale();
       preload='none'
       style={{ aspectRatio }}
     >
+      <source src={video.streamingUrl} type='application/vnd.apple.mpegurl' />
+      <source src={video.streamingUrl} type='application/x-mpegURL' />
       <source src={video.mp4Url} type='video/mp4' />
       { block.tracks.map(track => (
         <track

--- a/src/blocks/VideoBlock/VideoBlock.astro
+++ b/src/blocks/VideoBlock/VideoBlock.astro
@@ -1,0 +1,41 @@
+---
+import type { UploadVideoField, VideoBlockFragment } from '@lib/types/datocms';
+
+interface Props {
+  block: VideoBlockFragment;
+}
+const { block } = Astro.props;
+const { alt, width, height } = block.videoAsset;
+const video = block.videoAsset.video as UploadVideoField;
+const aspectRatio = width && height ? width / height : null;
+---
+
+<figure>
+  <video
+    poster={video.thumbnailUrl}
+    controls
+    autoplay={block.autoplay ? 'true' : 'false'}
+    loop={block.loop ? 'true' : 'false'}
+    muted={block.mute ? 'true' : 'false'}
+    width={width}
+    height={height}
+    preload='none'
+    style={{ aspectRatio }}
+  >
+    <source src={video.mp4Url} type='video/mp4' />
+    {alt}
+  </video>
+
+  {block.title && <figcaption>{block.title}</figcaption>}
+</figure>
+
+<pre><code>VideoBlock: {JSON.stringify(block, null, 2)}</code></pre>
+
+<style>
+  video {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    object-fit: contain;
+  }
+</style>

--- a/src/blocks/VideoBlock/VideoBlock.client.ts
+++ b/src/blocks/VideoBlock/VideoBlock.client.ts
@@ -35,7 +35,7 @@ class VideoBlock extends HTMLElement {
     this.#autoplay = (this.dataset.autoplay === 'true') && !this.#useDataSaveMode && !this.#useReducedMotion;
     this.#mp4Url = this.dataset.mp4Url;
     this.#streamingUrl = this.dataset.streamingUrl;
-    this.#video = this.querySelector('video') as HTMLVideoElement;
+    this.#video = this.querySelector('video[data-video]') as HTMLVideoElement;
   }
 
   connectedCallback() {

--- a/src/blocks/VideoBlock/VideoBlock.client.ts
+++ b/src/blocks/VideoBlock/VideoBlock.client.ts
@@ -27,7 +27,6 @@ class VideoBlock extends HTMLElement {
 
     const useReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     if (this.#autoplay && !useDataSaveMode && !useReducedMotion) {
-      console.log('play?');
       this.play({ focus: false });
     }
   }

--- a/src/blocks/VideoBlock/VideoBlock.client.ts
+++ b/src/blocks/VideoBlock/VideoBlock.client.ts
@@ -1,16 +1,29 @@
-/**
- * Save Data mode is experimental untyped browser feature, so needs a bit of voodoo:
- * @see https://web.dev/articles/optimizing-content-efficiency-save-data
- * @see https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation
- */
-const useDataSaveMode = (() => {
-  type NetworkInformation = { saveData: boolean; }
-  const connection = (navigator as unknown as { connection: NetworkInformation }).connection;
-  return connection.saveData === true; 
-})();
+const enhanceIntersectedVideoBlocks = (entries: IntersectionObserverEntry[]) => {
+  entries.forEach((entry) => {
+    if (entry.isIntersecting && entry.target instanceof VideoBlock) {
+      entry.target.enhance();
+    }
+  });
+};
+
+const videoBlockObserver = new IntersectionObserver(
+  enhanceIntersectedVideoBlocks,
+  { rootMargin: '0px', threshold: [.5] }
+);
 
 class VideoBlock extends HTMLElement {
   #autoplay = false;
+  #useReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  /**
+   * Save Data mode is experimental untyped browser feature, so needs a bit of voodoo:
+   * @see https://web.dev/articles/optimizing-content-efficiency-save-data
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation
+   */
+  #useDataSaveMode = (() => {
+    type NetworkInformation = { saveData: boolean; }
+    const connection = (navigator as unknown as { connection: NetworkInformation }).connection;
+    return connection.saveData === true; 
+  })();
   #video: HTMLVideoElement;
 
   constructor() { 
@@ -24,9 +37,13 @@ class VideoBlock extends HTMLElement {
       console.warn('VideoBlock: missing required elements/attributes', this);
       return;
     }
+    videoBlockObserver.observe(this);
+  }
 
-    const useReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    if (this.#autoplay && !useDataSaveMode && !useReducedMotion) {
+  enhance() {
+    videoBlockObserver.unobserve(this);
+
+    if (this.#autoplay && !this.#useDataSaveMode && !this.#useReducedMotion) {
       this.play({ focus: false });
     }
   }

--- a/src/blocks/VideoBlock/VideoBlock.client.ts
+++ b/src/blocks/VideoBlock/VideoBlock.client.ts
@@ -1,3 +1,5 @@
+import { getLocale } from '@lib/i18n';
+
 const enhanceIntersectedVideoBlocks = (entries: IntersectionObserverEntry[]) => {
   entries.forEach((entry) => {
     if (entry.isIntersecting && entry.target instanceof VideoBlock) {
@@ -59,6 +61,17 @@ class VideoBlock extends HTMLElement {
     this.play({ focus: true });
   }
 
+  /**
+   * HLS stream ignores <track default> attribute, so we enable it manually:
+   */
+  showTextTrack() {
+    const defaultTrack = [...this.#video.textTracks]
+      .find((track) => track.language === getLocale());
+    if (defaultTrack) {
+      defaultTrack.mode = 'showing';
+    }
+  }
+
   enhance() {
     videoBlockObserver.unobserve(this);
     if (this.#autoplay) {
@@ -70,6 +83,7 @@ class VideoBlock extends HTMLElement {
     const Hls = await getHlsPlayer().then(({ default: Hls }) => Hls);
     const playAndFocus = () => {
       this.#video.play();
+      this.showTextTrack();
       if (focus) {
         this.#video.focus();
       }

--- a/src/blocks/VideoBlock/VideoBlock.client.ts
+++ b/src/blocks/VideoBlock/VideoBlock.client.ts
@@ -1,0 +1,43 @@
+/**
+ * Save Data mode is experimental untyped browser feature, so needs a bit of voodoo:
+ * @see https://web.dev/articles/optimizing-content-efficiency-save-data
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation
+ */
+const useDataSaveMode = (() => {
+  type NetworkInformation = { saveData: boolean; }
+  const connection = (navigator as unknown as { connection: NetworkInformation }).connection;
+  return connection.saveData === true; 
+})();
+
+class VideoBlock extends HTMLElement {
+  #autoplay = false;
+  #video: HTMLVideoElement;
+
+  constructor() { 
+    super();
+    this.#autoplay = this.dataset.autoplay === 'true';
+    this.#video = this.querySelector('video') as HTMLVideoElement;
+  }
+
+  connectedCallback() {
+    if (!this.#video) {
+      console.warn('VideoBlock: missing required elements/attributes', this);
+      return;
+    }
+
+    const useReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (this.#autoplay && !useDataSaveMode && !useReducedMotion) {
+      console.log('play?');
+      this.play({ focus: false });
+    }
+  }
+
+  play({ focus }: { focus: boolean }) {
+    this.#video.play();
+    if (focus) {
+      this.#video.focus();
+    }
+  }
+}
+
+customElements.define('video-block', VideoBlock);

--- a/src/blocks/VideoBlock/VideoBlock.fragment.graphql
+++ b/src/blocks/VideoBlock/VideoBlock.fragment.graphql
@@ -1,0 +1,22 @@
+fragment VideoBlock on VideoBlockRecord {
+  id
+  videoAsset {
+    video {
+      duration
+      framerate
+      mp4Url
+      muxAssetId
+      muxPlaybackId
+      streamingUrl
+      thumbnailUrl(format: jpg)
+    }
+    width
+    height
+    alt
+    title
+  }
+  title
+  autoplay
+  mute
+  loop
+}

--- a/src/blocks/VideoBlock/VideoBlock.fragment.graphql
+++ b/src/blocks/VideoBlock/VideoBlock.fragment.graphql
@@ -19,4 +19,12 @@ fragment VideoBlock on VideoBlockRecord {
   autoplay
   mute
   loop
+  tracks {
+    title
+    locale
+    kind
+    file {
+      url
+    }
+  }
 }

--- a/src/blocks/VideoBlock/VideoFallback.astro
+++ b/src/blocks/VideoBlock/VideoFallback.astro
@@ -1,0 +1,26 @@
+---
+import type { UploadVideoField } from '@lib/types/datocms';
+
+interface Props {
+  alt?: null | string;
+  video: UploadVideoField;
+}
+const { alt = '', video } = Astro.props;
+---
+
+{/* Fallback content for browsers that don't support the video element */}
+<a href={video.mp4Url} download>
+  <img src={video.thumbnailUrl} alt={alt} />
+</a>
+
+<style>
+  a,
+  img {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+  img {
+    object-fit: cover;
+  }
+</style>

--- a/src/blocks/VideoBlock/VideoFallback.astro
+++ b/src/blocks/VideoBlock/VideoFallback.astro
@@ -1,15 +1,19 @@
 ---
 import type { UploadVideoField } from '@lib/types/datocms';
+import { t } from '@lib/i18n';
 
 interface Props {
   alt?: null | string;
+  title?: null | string;
   video: UploadVideoField;
 }
-const { alt = '', video } = Astro.props;
+const alt = Astro.props.alt || '';
+const title = Astro.props.title || '';
+const video = Astro.props.video;
 ---
 
 {/* Fallback content for browsers that don't support the video element */}
-<a href={video.mp4Url} download>
+<a href={video.mp4Url} download aria-label={ t('download_video_title', { title }) }>
   <img src={video.thumbnailUrl} alt={alt} />
 </a>
 

--- a/src/blocks/VideoBlock/VideoTextTracks.astro
+++ b/src/blocks/VideoBlock/VideoTextTracks.astro
@@ -1,14 +1,13 @@
 ---
 import type { VideoTextTrackRecord } from '@lib/types/datocms';
-import { getLocale, getLocaleName } from '@lib/i18n';
-const activeLocale = getLocale();
+import { getLocaleName } from '@lib/i18n';
 
 interface Props {
   tracks: VideoTextTrackRecord[];
 }
 const { tracks } = Astro.props;
 ---
-
+{ /* track[default] attribute makes default track invisible, so it's enabled in the client-side script instead */ }
 {
   tracks.map((track) => (
     <track
@@ -16,7 +15,6 @@ const { tracks } = Astro.props;
       label={track.title || getLocaleName(track.locale)}
       src={track.file.url}
       srclang={track.locale}
-      default={track.locale === activeLocale}
     />
   ))
 }

--- a/src/blocks/VideoBlock/VideoTextTracks.astro
+++ b/src/blocks/VideoBlock/VideoTextTracks.astro
@@ -1,0 +1,22 @@
+---
+import type { VideoTextTrackRecord } from '@lib/types/datocms';
+import { getLocale, getLocaleName } from '@lib/i18n';
+const activeLocale = getLocale();
+
+interface Props {
+  tracks: VideoTextTrackRecord[];
+}
+const { tracks } = Astro.props;
+---
+
+{
+  tracks.map((track) => (
+    <track
+      kind={track.kind}
+      label={track.title || getLocaleName(track.locale)}
+      src={track.file.url}
+      srclang={track.locale}
+      default={track.locale === activeLocale}
+    />
+  ))
+}

--- a/src/blocks/VideoEmbedBlock/README.md
+++ b/src/blocks/VideoEmbedBlock/README.md
@@ -10,3 +10,4 @@
 - Reserves space for image to prevent page reflow.
 - Conditionally loads video on click or when autoplay is set.
 - Has a responsive video cover image that lazy loads image for better performance.
+- Requires user to give consent due to third party tracking (see [#49: consent manager](https://github.com/voorhoede/head-start/issues/49)). Alternatively use [Video Block](../VideoBlock/) with video uploaded in DatoCMS, served without tracking.

--- a/src/components/LocaleSelector/LocaleSelector.astro
+++ b/src/components/LocaleSelector/LocaleSelector.astro
@@ -30,6 +30,7 @@ const getPageHref = (locale: SiteLocale) => {
           <a hreflang={ locale }
             href={ getPageHref(locale as SiteLocale) }
             aria-current={ locale === activeLocale ? 'page' : 'false' }>
+            { /* tip: use @lib/i18n getLocaleName for locale names ('English', 'Deutsch', etc) */ }
             { locale }
           </a>
         </li>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -24,3 +24,24 @@ export function setLocale(locale?: SiteLocale) {
   }
   return i18n.locale();
 }
+
+/**
+ * Returns locale name for a given code in its own language.
+ * This method only supports a few languages, to keep the bundle size small when used client-side.
+ * To add more, see: https://github.com/adlawson/nodejs-langs/blob/master/data.js (not available in ESM)
+ */
+export function getLocaleName(code: string) {
+  const localeNamesByCode = {
+    'de': 'Deutsch',
+    'en': 'English',
+    'es': 'Español',
+    'fr': 'Français',
+    'it': 'Italiano',
+    'nl': 'Nederlands',
+  };
+  const localeName = localeNamesByCode[code as keyof typeof localeNamesByCode];
+  if (localeName) {
+    return localeName;
+  }
+  return code.toUpperCase();
+}

--- a/src/pages/[locale]/[...path]/index.query.graphql
+++ b/src/pages/[locale]/[...path]/index.query.graphql
@@ -5,6 +5,7 @@
 #import '@blocks/TableBlock/TableBlock.fragment.graphql'
 #import '@blocks/TextBlock/TextBlock.fragment.graphql'
 #import '@blocks/TextImageBlock/TextImageBlock.fragment.graphql'
+#import '@blocks/VideoBlock/VideoBlock.fragment.graphql'
 #import '@blocks/VideoEmbedBlock/VideoEmbedBlock.fragment.graphql'
 
 query Page($locale: SiteLocale!, $slug: String!) {
@@ -40,6 +41,9 @@ query Page($locale: SiteLocale!, $slug: String!) {
       }
       ... on TextImageBlockRecord {
         ...TextImageBlock
+      }
+      ... on VideoBlockRecord {
+        ...VideoBlock
       }
       ... on VideoEmbedBlockRecord {
         ...VideoEmbedBlock

--- a/src/pages/[locale]/index.query.graphql
+++ b/src/pages/[locale]/index.query.graphql
@@ -4,6 +4,7 @@
 #import '@blocks/TableBlock/TableBlock.fragment.graphql'
 #import '@blocks/TextBlock/TextBlock.fragment.graphql'
 #import '@blocks/TextImageBlock/TextImageBlock.fragment.graphql'
+#import '@blocks/VideoBlock/VideoBlock.fragment.graphql'
 #import '@blocks/VideoEmbedBlock/VideoEmbedBlock.fragment.graphql'
 
 query Home($locale: SiteLocale!) {
@@ -33,6 +34,9 @@ query Home($locale: SiteLocale!) {
       }
       ... on TextImageBlockRecord {
         ...TextImageBlock
+      }
+      ... on VideoBlockRecord {
+        ...VideoBlock
       }
       ... on VideoEmbedBlockRecord {
         ...VideoEmbedBlock


### PR DESCRIPTION
# Changes

Adds Video Block that renders a video uploaded in DatoCMS with a cover image, caption, support for subtitles and options to autoplay, mute and loop. Features (also in block readme):

- Privacy first alternative to [Video Embed Block](../VideoEmbedBlock/), as video uploaded in DatoCMS is served without tracking (no consent required).
- Supports video streaming with adaptive bitrate (using HLS) for best UX and performance.
- Fallback to mp4 video when streaming is not available.
- Fallback to video download link when HTML video element is not supported.
- Supports subtitle tracks for enhanced accessibility, automatically selecting default locale when available.
- Supports figcaption defaulting to external video's title and optional custom title override.
- Supports autoplay, mute and loop.
- Autoplay is only triggered if no reduced motion is preferred (for a11y) and save data mode is off.
- Conditionally loads video and streaming package (`hls.js`) on click or when in view in case autoplay is enabled.

Moved [custom image and custom play button overlay to separate ticket](https://github.com/voorhoede/head-start/issues/121).

# Associated issue

Resolves #33 

# How to test

1. Open [`/en/overview-page/demos/video-block/`](https://feat-video-block.head-start.pages.dev/en/overview-page/demos/video-block/)
2. Test with different uploaded videos in CMS, with and without subtitles
3. Verify streaming, mp4 and fallback work (by disabling one at a time locally)
4. Verify autoplay and other block options work as expected

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
