### PR TITLE
chore: Page postfix on models; blocks on Not Found Page

### DIFF
--- a/config/datocms/migrations/1706526286_pageModelNames.ts
+++ b/config/datocms/migrations/1706526286_pageModelNames.ts
@@ -1,0 +1,82 @@
+import type { Client } from '@datocms/cli/lib/cma-client-node';
+
+export default async function (client: Client) {
+  console.log('Creating new fields/fieldsets');
+
+  console.log(
+    'Create Modular content field "Body" (`body_blocks`) in model "\uD83E\uDD37 Not found" (`not_found_page`)'
+  );
+  await client.fields.create('2776649', {
+    // @ts-expect-error next-line DatoCMS auto-generated
+    id: 'Zu006Xq0TMCAvV-vyQ_Iiw',
+    label: 'Body',
+    field_type: 'rich_text',
+    api_key: 'body_blocks',
+    localized: true,
+    validators: {
+      rich_text_blocks: {
+        item_types: [
+          'BRbU6VwTRgmG5SbwUs0rBg',
+          'PAk40zGjQJCcDXXPgygUrA',
+          'QYfZyBzIRWKxA1MinIR0aQ',
+          'VZvVfu52RZK81WG0Dxp-FQ',
+          'V80liDVtRC-UYgd3Sm-dXg',
+          'ZdBokLsWRgKKjHrKeJzdpw',
+          'gezG9nO7SfaiWcWnp-HNqw',
+          '0SxYNS2CR1it_5LHYWuEQg',
+        ],
+      },
+    },
+    appearance: {
+      addons: [],
+      editor: 'rich_text',
+      parameters: { start_collapsed: true },
+    },
+  });
+
+  console.log('Finalize models/block models');
+
+  console.log('Update model "\uD83C\uDFE0 Home" (`home_page`)');
+  await client.itemTypes.update('2216253', {
+    name: '\uD83C\uDFE0 Home',
+    api_key: 'home_page',
+  });
+
+  console.log('Update model "\uD83C\uDF10 Translation" (`translation`)');
+  await client.itemTypes.update('2229390', {
+    name: '\uD83C\uDF10 Translation',
+  });
+
+  console.log('Update model "\uD83D\uDCD1 Page" (`page`)');
+  await client.itemTypes.update('2596445', { name: '\uD83D\uDCD1 Page' });
+
+  console.log('Update model "\uD83E\uDD37 Not found" (`not_found_page`)');
+  await client.itemTypes.update('2776649', {
+    name: '\uD83E\uDD37 Not found',
+    api_key: 'not_found_page',
+  });
+
+  console.log(
+    'Update block model "\uD83D\uDDBC\uFE0F Image Block" (`image_block`)'
+  );
+  await client.itemTypes.update('ZdBokLsWRgKKjHrKeJzdpw', {
+    name: '\uD83D\uDDBC\uFE0F Image Block',
+  });
+
+  console.log('Update block model "\uD83D\uDCDD Text Block" (`text_block`)');
+  await client.itemTypes.update('PAk40zGjQJCcDXXPgygUrA', {
+    name: '\uD83D\uDCDD Text Block',
+  });
+
+  console.log(
+    'Update block model "\uD83C\uDFAC Video Embed Block" (`video_embed_block`)'
+  );
+  await client.itemTypes.update('gezG9nO7SfaiWcWnp-HNqw', {
+    name: '\uD83C\uDFAC Video Embed Block',
+  });
+
+  console.log('Manage menu items');
+
+  console.log('Update menu item "\uD83E\uDD37 404 Page"');
+  await client.menuItems.update('1690698', { label: '\uD83E\uDD37 404 Page' });
+}

--- a/datocms-environment.ts
+++ b/datocms-environment.ts
@@ -3,5 +3,5 @@
  * @see docs/getting-started.md on how to use this file
  * @see docs/decision-log/2023-10-24-datocms-env-file.md on why file is preferred over env vars
  */
-export const datocmsEnvironment = 'video-block';
+export const datocmsEnvironment = 'page-model-names';
 export const datocmsBuildTriggerId = '30535';

--- a/docs/cms-content-modelling.md
+++ b/docs/cms-content-modelling.md
@@ -10,14 +10,14 @@ In Head Start content is named in this order of preference:
 
 1. Naming based on data type (for example `slug`, `image`, `color`).
 2. Naming based on function (for example `title`, `autoplay`).
-3. Naming based on appearance (for example `layout`, `theme`).
+3. Naming based on appearance (for example `layout`, `style`).
 
 Specific cases:
 
 - In case of a boolean field it should be named after its function, as a boolean means nothing without context. For example a `Video Block` could have `autoplay`, `loop` and `muted` boolean fields.
 - In case a model has multiple fields of the same data type, the primary field should be named after its data type (for example `image`) and secondary fields should be named after their function (for example `background_image`).
 - In case a field is named after its function, the validations you configure for the field are typically a good indicator towards a fitting name. For example if you set a single line string field to only accept a URL as a pattern, `url` is probably a good name for the field.
-- In case a field is only added to control the appearance of a model in the user interface, Head Start proposes to solve this with a generic `layout` and `theme` field. See [Modelling Appearance](#modelling-appearance).
+- In case a field is only added to control the appearance of a model in the user interface, Head Start proposes to solve this with a generic `layout` and `style` field. See [Modelling Appearance](#modelling-appearance).
 
 ## Model name conventions
 
@@ -55,12 +55,12 @@ In cases where the appearance of a content model needs to be controlled from the
 Field name | Field type | Notes
 --- | --- | ---
 `layout` | single line string field | Defines position, size and direction. Use pre-defined values by configuring [accept only specified values](https://www.datocms.com/docs/content-modelling/validations#single-line-text) in field validation settings. For example `full-width`, `centered`, `fixed-header`.
-`theme` | single line string field or [link field](https://www.datocms.com/docs/content-modelling/links) | Defines other visual style properties. Use string field with pre-defined values by configuring [accept only specified values](https://www.datocms.com/docs/content-modelling/validations#single-line-text) or create a dedicated Theme model and use a link field to reference it, if the theme is used cross-model. For example `highlight`, `branded`.
+`style` | single line string field or [link field](https://www.datocms.com/docs/content-modelling/links) | Defines other visual style properties. Use string field with pre-defined values by configuring [accept only specified values](https://www.datocms.com/docs/content-modelling/validations#single-line-text) or create a dedicated Style model and use a link field to reference it, if the style is used cross-model. For example `highlight`, `branded`, `primary`.
 
 A few example situations:
 
 - A design has a block with two text columns. Avoid creating fields like `text_column_left` and `text_column_right`. Instead create an `items` field (see [Field name conventions](#field-name-conventions)) where each item has a `text` field, and use validations to set a minimum and maximum number of items. Then add a `layout` field to the block with values like `one-column`, `two-columns`, `multi-column`.
 - A design has two variations of a block. One with an image on the left and text on the right. The second with the content the other way around. Avoid making multiple blocks or adding an `is_inversed` or `is_image_left` field. Instead create a `layout` field and only allow specific values describing the options, like `image-text` and `text-image`. You can use the presentation of the field to display the options as radio buttons or a dropdown if desired (this doesn't impact the data model). This setup is open to future extension. And if the website later adds right-to-left support the content model doesn't need to change.
 - A design has different blocks all showing multiple images. Here conbining an `images` field with a `layout` field with options like `grid` and `gallery` would allow you to model a single content block for both design options. Note: f this feels confusing to editors or if the blocks differ in more ways you may still want to create multiple content blocks in the CMS.
-- A design has two variations of a blocks background. Avoid fields like `is_gray` as this makes it difficult to add variations later on, or change an existing variation. Instead use a `theme` field with values like `default`, `dimmed` or `highlighted`.
-- A design consistently uses multiple theme variations across the website. In this case, create a new Theme model and create records for each variation. Add `theme` link fields to blocks and models referencing the Theme model. You can restrict modifying the Theme records to admins under [Content Permissions in the CMS](https://www.datocms.com/docs/content-delivery-api/docs/general-concepts/roles-and-permission-system#content-level-permissions).
+- A design has two variations of a blocks background. Avoid fields like `is_gray` as this makes it difficult to add variations later on, or change an existing variation. Instead use a `style` field with values like `default`, `dimmed` or `highlighted`.
+- A design consistently uses multiple style variations across the website. In this case, create a new Style model and create records for each variation. Add `style` link fields to blocks and models referencing the Style model. You can restrict modifying the Style records to admins under [Content Permissions in the CMS](https://www.datocms.com/docs/content-delivery-api/docs/general-concepts/roles-and-permission-system#content-level-permissions).

--- a/src/blocks/InternalLink/InternalLink.astro
+++ b/src/blocks/InternalLink/InternalLink.astro
@@ -20,7 +20,7 @@ const getHref = (
     { locale: SiteLocale, page: InternalLinkFragment['page'] 
   }) => {
   const pathParams = {
-    HomeRecord: [],
+    HomePageRecord: [],
     PageRecord: [getPagePath({ page: page as PageRecord, locale })],
   }[page.__typename];
   

--- a/src/blocks/InternalLink/InternalLink.fragment.graphql
+++ b/src/blocks/InternalLink/InternalLink.fragment.graphql
@@ -13,7 +13,7 @@ fragment InternalLink on InternalLinkRecord {
       }
       ...ParentPage
     }
-    ... on HomeRecord {
+    ... on HomePageRecord {
       title
     }
   }

--- a/src/pages/[locale]/404.astro
+++ b/src/pages/[locale]/404.astro
@@ -1,8 +1,10 @@
 ---
 import { datocmsRequest } from '@lib/datocms';
-import type { NotFoundQuery, NotFoundRecord } from '@lib/types/datocms.d.ts';
+import type { NotFoundPageQuery, NotFoundPageRecord } from '@lib/types/datocms.d.ts';
 import query from './404.query.graphql';
 import Layout from '@layouts/Default.astro';
+import Blocks from '@blocks/Blocks.astro';
+import type { AnyBlock } from '@blocks/Blocks';
 import { locales } from '@lib/i18n';
 import { noIndexTag, titleTag } from '@lib/seo';
 
@@ -13,11 +15,12 @@ export async function getStaticPaths() {
 }
 
 const { locale } = Astro.params;
-const { page } = await datocmsRequest<NotFoundQuery>({ query, variables: { locale } }) as { page: NotFoundRecord };
+const { page } = await datocmsRequest<NotFoundPageQuery>({ query, variables: { locale } }) as { page: NotFoundPageRecord };
 ---
 <Layout
   pageUrls={[]}
   seoMetaTags={[ noIndexTag, titleTag(page.title) ]}
 >
   <h1>{ page.title }</h1>
+  <Blocks blocks={page.bodyBlocks as AnyBlock[]} />
 </Layout>

--- a/src/pages/[locale]/404.query.graphql
+++ b/src/pages/[locale]/404.query.graphql
@@ -1,5 +1,41 @@
-query NotFound($locale: SiteLocale!) {
-  page: notFound(locale: $locale) {
+#import '@blocks/EmbedBlock/EmbedBlock.fragment.graphql'
+#import '@blocks/ImageBlock/ImageBlock.fragment.graphql'
+#import '@blocks/PagePartialBlock/PagePartialBlock.fragment.graphql'
+#import '@blocks/TableBlock/TableBlock.fragment.graphql'
+#import '@blocks/TextBlock/TextBlock.fragment.graphql'
+#import '@blocks/TextImageBlock/TextImageBlock.fragment.graphql'
+#import '@blocks/VideoBlock/VideoBlock.fragment.graphql'
+#import '@blocks/VideoEmbedBlock/VideoEmbedBlock.fragment.graphql'
+
+query NotFoundPage($locale: SiteLocale!) {
+  page: notFoundPage(locale: $locale) {
     title
+    bodyBlocks {
+      __typename
+      ... on EmbedBlockRecord {
+        ...EmbedBlock
+      }
+      ... on ImageBlockRecord {
+        ...ImageBlock
+      }
+      ... on PagePartialBlockRecord {
+        ...PagePartialBlock
+      }
+      ... on TableBlockRecord {
+        ...TableBlock
+      }
+      ... on TextBlockRecord {
+        ...TextBlock
+      }
+      ... on TextImageBlockRecord {
+        ...TextImageBlock
+      }
+      ... on VideoBlockRecord {
+        ...VideoBlock
+      }
+      ... on VideoEmbedBlockRecord {
+        ...VideoEmbedBlock
+      }
+    }
   }
 }

--- a/src/pages/[locale]/index.astro
+++ b/src/pages/[locale]/index.astro
@@ -1,6 +1,6 @@
 ---
 import { datocmsRequest } from '@lib/datocms';
-import type { HomeQuery, HomeRecord } from '@lib/types/datocms';
+import type { HomePageQuery, HomePageRecord } from '@lib/types/datocms';
 import type { PageUrl } from '@lib/types/page-url';
 import { locales } from '@lib/i18n';
 import Layout from '@layouts/Default.astro';
@@ -16,7 +16,7 @@ export async function getStaticPaths() {
 
 const { locale } = Astro.params;
 const variables = { locale };
-const { page } = await datocmsRequest<HomeQuery>({ query, variables }) as { page: HomeRecord };
+const { page } = await datocmsRequest<HomePageQuery>({ query, variables }) as { page: HomePageRecord };
 const pageUrls = locales.map(locale => ({ locale, pathname: `/${locale}/` })) as PageUrl[];
 ---
 <Layout 

--- a/src/pages/[locale]/index.query.graphql
+++ b/src/pages/[locale]/index.query.graphql
@@ -7,8 +7,8 @@
 #import '@blocks/VideoBlock/VideoBlock.fragment.graphql'
 #import '@blocks/VideoEmbedBlock/VideoEmbedBlock.fragment.graphql'
 
-query Home($locale: SiteLocale!) {
-  page: home(locale: $locale) {
+query HomePage($locale: SiteLocale!) {
+  page: homePage(locale: $locale) {
     title
     _seoMetaTags {
       attributes


### PR DESCRIPTION
# Changes

- Adds Page postfix to `HomePage` and `notFoundPage` to match docs on content modelling.
- Adds missing bodyBlocks to notFoundPage (should have been there already).
- Changes field name recommendation from `theme` to `style` to fit more use cases like `primary` on actions/buttons/links)

# Associated issue

N/A

# How to test

1. Open deploy preview
2. Verify everything still works as before, including 404 page.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- ~~I have notified a reviewer~~ (small changes to match documentation)

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
