### PR TITLE
fix: Preview mode routing

### DIFF
--- a/config/preview.ts
+++ b/config/preview.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 
-export const previewBranches = ['preview', 'feat/preview-mode', 'fix/function-size'];
+export const previewBranches = ['preview', 'feat/preview-mode', 'fix/function-size', 'fix/preview-mode-routing'];
 
 function getGitBranch() {
   const branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim();

--- a/docs/preview-mode.md
+++ b/docs/preview-mode.md
@@ -26,10 +26,10 @@ Preview mode is protected with a secret. If you attempt to view content protecte
 
 ```bash
 # by default 'enter preview' redirects to home page:
-/api/preview/enter?secret=my-little-secret
+/api/preview/enter/?secret=my-little-secret
 
 # you can use `location` to redirect to another page:
-/api/preview/enter?secret=my-little-secret&location=/en/some-page/
+/api/preview/enter/?secret=my-little-secret&location=/en/some-page/
 ```
 
 This endpoint can for example be used to link to previews from within the CMS.
@@ -38,10 +38,10 @@ When authorised an encrypted cookie is set, to persist preview mode throughout a
 
 ```bash
 # by default 'exit preview' redirects to home page:
-/api/preview/exit
+/api/preview/exit/
 
 # you can use `location` to redirect to another page:
-/api/preview/exit?location=/en/some-page/
+/api/preview/exit/?location=/en/some-page/
 ```
 
 Note: the secret is configured as environment variable `HEAD_START_PREVIEW_SECRET`.

--- a/src/components/PreviewMode/PreviewMode.astro
+++ b/src/components/PreviewMode/PreviewMode.astro
@@ -8,7 +8,7 @@ const { datocmsEnvironment, datocmsToken, isPreview } = Astro.locals;
   <preview-mode-bar>  
     Preview mode
     <span role="presentation" data-status="closed" />
-    <a href={ `/api/preview/exit?location=${Astro.url}` }>exit preview</a>
+    <a href={ `/api/preview/exit/?location=${Astro.url}` }>exit preview</a>
   </preview-mode-bar>
   <slot />
 </preview-mode>

--- a/src/components/PreviewMode/PreviewModeLogin.astro
+++ b/src/components/PreviewMode/PreviewModeLogin.astro
@@ -1,7 +1,7 @@
 ---
 const location = new URL(Astro.request.url).pathname;
 ---
-<form method="get" action="/api/preview/enter">
+<form method="get" action="/api/preview/enter/">
   <h1>Preview mode</h1>
   <p>You currently don't have access to preview mode. Enter the preview secret below or follow the preview links from the CMS.</p>
   <div>

--- a/src/pages/[locale]/[...path]/_Page.astro
+++ b/src/pages/[locale]/[...path]/_Page.astro
@@ -1,0 +1,52 @@
+---
+import { datocmsRequest } from '@lib/datocms';
+import type { PageQuery, PageRecord, SiteLocale } from '@lib/types/datocms';
+import type { PageUrl } from '@lib/types/page-url';
+import Layout from '@layouts/Default.astro';
+import Blocks from '@blocks/Blocks.astro';
+import type { AnyBlock } from '@blocks/Blocks';
+import {
+  getParentPages,
+  getPagePath,
+  getPageSlugFromPath,
+} from '@blocks/InternalLink';
+import { formatBreadcrumb } from '@components/Breadcrumbs';
+import PreviewModeSubscription from '@components/PreviewMode/PreviewModeSubscription.astro';
+import ShareButton from '@components/ShareButton/ShareButton.astro';
+import query from './_index.query.graphql';
+
+type Params = {
+  locale: SiteLocale;
+  path: string;
+};
+
+const { locale, path } = Astro.params as Params;
+const variables = { locale, slug: getPageSlugFromPath(path) };
+const { page } = (await datocmsRequest<PageQuery>({ query, variables })) as {
+  page: PageRecord;
+};
+const breadcrumbs = [...getParentPages(page), page].map((page) =>
+  formatBreadcrumb({
+    text: page.title,
+    href: `/${locale}/${getPagePath({ page, locale })}/`,
+  })
+);
+const pageUrls = (page._allSlugLocales || []).map(({ locale }) => ({
+  locale: locale as SiteLocale,
+  pathname: `/${locale}/${getPagePath({
+    page,
+    locale: locale as SiteLocale,
+  })}/`,
+})) as PageUrl[];
+---
+
+<Layout
+  breadcrumbs={breadcrumbs}
+  pageUrls={pageUrls}
+  seoMetaTags={page._seoMetaTags}
+>
+  <PreviewModeSubscription query={query} variables={variables} />
+  <h1>{page.title}</h1>
+  <Blocks blocks={page.bodyBlocks as AnyBlock[]} />
+  <ShareButton />
+</Layout>

--- a/src/pages/[locale]/[...path]/index.astro
+++ b/src/pages/[locale]/[...path]/index.astro
@@ -1,19 +1,9 @@
 ---
-import { datocmsCollection, datocmsRequest } from '@lib/datocms';
-import type { PageQuery, PageRecord, ParentPageFragment, SiteLocale } from '@lib/types/datocms';
-import type { PageUrl } from '@lib/types/page-url';
-import Layout from '@layouts/Default.astro';
-import Blocks from '@blocks/Blocks.astro';
-import type { AnyBlock } from '@blocks/Blocks';
-import {
-  getParentPages,
-  getPagePath,
-  getPageSlugFromPath,
-} from '@blocks/InternalLink';
-import { formatBreadcrumb } from '@components/Breadcrumbs';
-import PreviewModeSubscription from '@components/PreviewMode/PreviewModeSubscription.astro';
-import ShareButton from '@components/ShareButton/ShareButton.astro';
-import query from './_index.query.graphql';
+import { datocmsCollection } from '@lib/datocms';
+import type { PageRecord, ParentPageFragment, SiteLocale } from '@lib/types/datocms';
+import { getPagePath } from '@blocks/InternalLink';
+import HomePage from '@pages/[locale]/index.astro';
+import Page from './_Page.astro';
 
 export async function getStaticPaths() {
   interface PagesCollectionItem {
@@ -47,33 +37,20 @@ export async function getStaticPaths() {
   });
 }
 
-type Params = {
-  locale: SiteLocale;
-  path: string;
-};
-
-const { locale, path } = Astro.params as Params;
-const variables = { locale, slug: getPageSlugFromPath(path) };
-const { page } = (await datocmsRequest<PageQuery>({ query, variables })) as {
-  page: PageRecord;
-};
-const breadcrumbs = [...getParentPages(page), page].map((page) => formatBreadcrumb({
-  text: page.title,
-  href: `/${locale}/${getPagePath({ page, locale })}/`,
-}));
-const pageUrls = (page._allSlugLocales || []).map(({ locale }) => ({
-  locale: locale as SiteLocale,
-  pathname: `/${locale}/${getPagePath({ page, locale: locale as SiteLocale })}/`,
-})) as PageUrl[];
+/**
+ * [...path] should not match when path is undefined.
+ * Due to an open issue in Astro it does: https://github.com/withastro/astro/issues/9103
+ * This means during SSR, when getStaticPaths is ignored, this route is also matched for the home page.
+ * This is only an issue for us in preview mode, not during a regular static deployment.
+ * As a workaround we check the path and conditionally render either the home page or the regular page.
+ */
+const { path } = Astro.params as { path?: string };
+const isHomeRoute = path === undefined;
 ---
 
-<Layout
-  breadcrumbs={breadcrumbs}
-  pageUrls={pageUrls}
-  seoMetaTags={page._seoMetaTags}
->
-  <PreviewModeSubscription query={query} variables={variables} />
-  <h1>{page.title}</h1>
-  <Blocks blocks={page.bodyBlocks as AnyBlock[]} />
-  <ShareButton />
-</Layout>
+{
+  isHomeRoute 
+  /* @ts-expect-error next-line workaround, see above */
+    ? <HomePage />
+    : <Page />
+}


### PR DESCRIPTION
# Changes

Errors occurred in preview mode caused by incorrect API route URLs and the new nested pages route (`[...path]`).
This PR resolves those by:

- Adds trailing slashes to preview API routes in templates and docs, as they are now required.
- Handle page route mismatch, caused by [open Astro issue](https://github.com/withastro/astro/issues/9103).

# Associated issue

N/A

# How to test

1. Open preview link
2. Enter preview secret
3. Verify you enter preview mode
4. Verify home page(s) render
5. Verify generic page(s) render
6. Exit preview mode
7. Verify that works too

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc) 👉 inline comments
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- ~~I have notified a reviewer~~

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
