### PR TITLE
feature: og:url in SeoHead

### DIFF
--- a/src/components/SeoHead.astro
+++ b/src/components/SeoHead.astro
@@ -28,7 +28,10 @@ const titleTag = tags.find(tag => tag.tag === 'title');
 
 { pageUrls.map((pageUrl: PageUrl) => (
   pageUrl.locale === locale
-    ? <link rel="canonical" href={ new URL(pageUrl.pathname, Astro.site) } />
+    ? <>
+      <link rel="canonical" href={ new URL(pageUrl.pathname, Astro.site) } />
+      <meta property="og:url" content={ new URL(pageUrl.pathname, Astro.site) } />
+    </>
     : <link rel="alternate" href={ new URL(pageUrl.pathname, Astro.site) } hreflang={ pageUrl.locale } />
 )) }
 


### PR DESCRIPTION
# Changes

Adds `og:url` to SeoHead, using the `canonical` URL value.

# Associated issue

N/A

# How to test

1. Open preview link
2. View source code (or use Heads Up to inspect)
3. Verify `og:url` is set correctly

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- ~~I have made updated relevant documentation files (in project README, docs/, etc)~~
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- ~~I have notified a reviewer~~ (tiny improvement)

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
