### PR TITLE
 133 VSCode settings replaces double quotes with single quotes in html

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "prettier.jsxSingleQuote": true,
-    "prettier.singleQuote": true
-}


### PR DESCRIPTION
# Changes

- Removes vscode settings.json

# Associated issue

Resolves #133 

# How to test

1. Grab an Astro file like the table block for example.
2. Change the single quotes from an import to double quotes.
3. Change de double quote from an html attribute to single quotes.
4. Do right mouse click and select `Format Document`.
5. Document should be formatted back to the previous state.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] ~~I have made updated relevant documentation files (in project README, docs/, etc)~~
- [x] ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [x] I have notified a reviewer
