### PR TITLE
fix(SkipLink): add datocms-no-index

### DIFF
--- a/src/components/SkipLink/SkipLink.astro
+++ b/src/components/SkipLink/SkipLink.astro
@@ -1,6 +1,5 @@
 ---
 import { t } from '@lib/i18n';
-import { datocmsNoIndex } from '@lib/search';
 import '@assets/a11y.css';
 
 interface Props {
@@ -9,7 +8,7 @@ interface Props {
 const { targetId } = Astro.props;
 ---
 
-<a href={`#${targetId}`} class="a11y-kb-only" {...datocmsNoIndex}>
+<a href={`#${targetId}`} class="a11y-kb-only" datocms-no-index="">
   <slot>{t('skip_to_content')}</slot>
 </a>
 

--- a/src/components/SkipLink/SkipLink.astro
+++ b/src/components/SkipLink/SkipLink.astro
@@ -1,5 +1,6 @@
 ---
 import { t } from '@lib/i18n';
+import { datocmsNoIndex } from '@lib/search';
 import '@assets/a11y.css';
 
 interface Props {
@@ -7,15 +8,16 @@ interface Props {
 }
 const { targetId } = Astro.props;
 ---
-<a href={`#${targetId}`} class="a11y-kb-only">
-  <slot>{ t('skip_to_content') }</slot>
+
+<a href={`#${targetId}`} class="a11y-kb-only" {...datocmsNoIndex}>
+  <slot>{t('skip_to_content')}</slot>
 </a>
 
 <style>
-/* basic styling, can be removed */
-a:focus {
-  position: absolute;
-  background: white;
-  padding: .5em;
-}
+  /* basic styling, can be removed */
+  a:focus {
+    position: absolute;
+    background: white;
+    padding: 0.5em;
+  }
 </style>


### PR DESCRIPTION
# Changes

Adds `datocms-no-index` attribute to the SkipLink component so it no longer appears in the search results.

# Associated issue

N/A. Screenshot of issue:

![image](https://github.com/voorhoede/head-start/assets/1516059/ccec3c31-d1b0-49b1-ab24-db02d655ce41)

# How to test

1. Open preview link
2. View source code
3. Verify SkipLink has a `datocms-no-attribute` just like the header and footer.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- ~~I have made updated relevant documentation files (in project README, docs/, etc)~~
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
