### PR TITLE
129-log-warning-for-missing-translation

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -11,7 +11,12 @@ const i18n = rosetta(messages);
 i18n.locale(defaultLocale);
 
 export type T = typeof i18n.t & ((key: TranslationKey) => string);
-export const t: T = i18n.t.bind(i18n);
+export const t: T = (key: TranslationKey) => {
+  const translate = i18n.t.bind(i18n);
+  const translation = translate(key);
+  if (!translation) console.warn(`\x1b[33mMissing translation for key: ${key}`);
+  return translation;
+};
 
 export function getLocale() {
   return i18n.locale();


### PR DESCRIPTION
# Changes

- Adds console warning to the translation function when there is no translation for that key

# Associated issue

Resolves #129 

# How to test

1. Open project on localhost
2. Add a random translation somewhere in the home page
3. There should be a yellow console warning in your terminal (Not in the browser console)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- [x] ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~ 
- [x] I have notified a reviewer
