### PR TITLE
fix(VideoEmbedBlock): correct layer order (z-index)

### DIFF
--- a/src/blocks/VideoEmbedBlock/VideoEmbedBlock.astro
+++ b/src/blocks/VideoEmbedBlock/VideoEmbedBlock.astro
@@ -113,18 +113,22 @@ function getVideoUrl({ loop, mute, video }: { loop: boolean; mute: boolean; vide
     width: 100%;
     background-color: #f1f1f1;
   }
-  img {
+
+  img,
+  iframe {
     position: absolute;
-    z-index: 0;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
+
+  }
+  img {
+    z-index: 0;
     object-fit: cover;
   }
   iframe {
-    position: absolute;
     z-index: 3;
-    width: 100%;
-    height: 100%;
     border: none;
   }
 


### PR DESCRIPTION
# Changes

Correct layer order (z-index) of elements in Video Embed Block.

# Associated issue

N/A

# How to test

I experienced this issue while developing the No Dodos website a while back. I kept this fix as a note, but forgot how to reproduce the issue 🤷 .

<!-- example:
1. Open preview link
2. Navigate to ...
3. Tap on ...
4. Verify that ...
5. Etc ...
-->

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [ ] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
