### PR TITLE
fix(Layout): locale in home link

### DIFF
--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -42,7 +42,7 @@ const mainContentId = 'content';
       <SkipLink targetId={ mainContentId } />
       <header { ...datocmsNoIndex }>
         { /* accessible home link, inspired by https://www.gov.uk/; with Microformats rel */ }
-        <a rel="home" href="/" aria-label={ t('go_to_home_page', { siteName }) }>[Logo]</a>
+        <a rel="home" href={ `/${ locale }/` } aria-label={ t('go_to_home_page', { siteName }) }>[Logo]</a>
         <div>
           <LocaleSelector pageUrls={ pageUrls } />
           <a rel="search" href={ getSearchPathname(locale) }>{ t('search') }</a>


### PR DESCRIPTION
# Changes

Home link in site header was missing the locale, causing unneeded redirects. This PR adds it.

# Associated issue

N/A

# How to test

1. Open preview link
2. Tap on home link in header
3. Verify that it directly navigates to the home page in the right locale without redirects

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- ~~I have made updated relevant documentation files (in project README, docs/, etc)~~
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
