### PR TITLE
fix(breadcrumbs): locale in home url

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs/Breadcrumbs.astro
@@ -1,5 +1,5 @@
 ---
-import { t } from '@lib/i18n';
+import { getLocale, t } from '@lib/i18n';
 import Icon from '@components/Icon';
 import type { Breadcrumb } from './index';
 
@@ -8,6 +8,7 @@ interface Props {
 }
 
 const { items } = Astro.props;
+const locale = getLocale();
 const isLast = (index: number) => index === items.length - 1;
 // @see https://developers.google.com/search/docs/appearance/structured-data/breadcrumb#json-ld
 const schema = {
@@ -17,7 +18,7 @@ const schema = {
     {
       '@type': 'ListItem',
       name: t('breadcrumbs_home'),
-      item: new URL('/', Astro.site),
+      item: new URL(`/${ locale }/`, Astro.site),
     },
     ... items.map(item => ({
       '@type': 'ListItem',
@@ -33,7 +34,7 @@ const schema = {
 
 <nav aria-label={t('breadcrumbs_title')}>
   <ol>
-    <li><a href='/'>{t('breadcrumbs_home')}</a></li>
+    <li><a href={ `/${ locale }/` }>{t('breadcrumbs_home')}</a></li>
     {
       items.map((item, index) => (
         <li>


### PR DESCRIPTION
# Changes

First breadcrumb linking to home page was missing the locale, causing unneeded redirects. This PR adds it.

# Associated issue

N/A

# How to test

1. Open preview link
2. Navigate to any nested page
3. Tap on home breadcrumb
4. Verify that it directly navigates to the home page in the right locale without redirects

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- ~~I have made updated relevant documentation files (in project README, docs/, etc)~~
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
