### PR TITLE
fix: TextImageBlock layout classname for direction row

### DIFF
--- a/src/blocks/TextImageBlock/TextImageBlock.astro
+++ b/src/blocks/TextImageBlock/TextImageBlock.astro
@@ -34,7 +34,7 @@ const { block } = Astro.props;
     display: flex;
     align-items: center;
   }
-  .layout--image-text {
+  .layout--text-image {
     flex-direction: row;
   }
   .layout--image-text {


### PR DESCRIPTION
# Changes

Fixes classname for layout with `flex-direction: row;` as both layout classes were showing the text and image in the same layout instead of opposites.

# Associated issue

N/A
# How to test

1. Open preview link
2. Navigate to [text image block demo](https://fix-text-image-block-layout.head-start.pages.dev/en/demos/text-image-block/)
3. Verify that different layouts show text and image in different order

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- ~~I have made updated relevant documentation files (in project README, docs/, etc)~~
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
