### PR TITLE
fix(Image): make sure images do not render larger than their intrinsic size

### DIFF
--- a/src/blocks/ImageBlock/Image.astro
+++ b/src/blocks/ImageBlock/Image.astro
@@ -18,7 +18,7 @@ const getImageSrc = (url: string, params: Record<string, number|string> = {}) =>
 
 const getImageSrcSet = (url: string, sizes = defaultSizes, params = {}) => {
   return sizes.map((size) => {
-    const src = getImageSrc(url, { ...params, w: size });
+    const src = getImageSrc(url, { ...params, w: size, fit: 'max' });
     return `${src} ${size}w`;
   }).join(', ');
 };
@@ -65,7 +65,7 @@ const imageUnavailableMessage = t('image_unavailable');
 /* functional styling */
 img {
   display: block;
-  width: 100%;
+  max-width: 100%;
   background-size: cover;
 }
 


### PR DESCRIPTION
# Changes

- Set a max-width of 100% in order to not render images larger then their intrinsic size
- Add an imgix parameter of fit: max in order to not upscale images larger then their intrinsic size

# Associated issue

Resolves #151

# How to test

1. Open preview link and see homepage. The voorhoede logo is an a png coming from imgix. The cake is an svg with a width an height set to 100px.
