### PR TITLE
Data fetching error from dato not shown in development

### DIFF
--- a/src/lib/datocms.ts
+++ b/src/lib/datocms.ts
@@ -43,6 +43,10 @@ export const datocmsRequest = async <T>({ query, variables = {}, retryCount = 1 
     if (retryCount >= retryLimit) throw Error('DatoCMS request failed. Too many retries.');
     return datocmsRequest({ query, variables, retryCount: retryCount + 1 });
   }
+  
+  if (!response.ok) {
+    throw Error(`DatoCMS request failed with status ${response.status}`);
+  }
 
   const { data, errors } = await response.json();
   if (errors) throw Error(JSON.stringify(errors, null, 4));

--- a/src/lib/datocms.ts
+++ b/src/lib/datocms.ts
@@ -45,7 +45,7 @@ export const datocmsRequest = async <T>({ query, variables = {}, retryCount = 1 
   }
 
   const { data, errors } = await response.json();
-  if (errors) throw Error(JSON.stringify(response, null, 4));
+  if (errors) throw Error(JSON.stringify(errors, null, 4));
   return data;
 };
 


### PR DESCRIPTION
# Changes

- Add error handling for both graphql errors as fetch errors when requesting datocms

# Associated issue

Resolves #149

# How to test

1. Locally screw up a graphql file and see relevant errors
2. Locally screw up datocmsRequest in datocms.ts, e.g. not passing headers and see a relevant error instead of page data being undefined
