### PR TITLE
Feat/anchor slot trim

### DIFF
--- a/src/blocks/InternalLink/InternalLink.astro
+++ b/src/blocks/InternalLink/InternalLink.astro
@@ -1,5 +1,9 @@
 ---
-import type { InternalLinkFragment, PageRecord, SiteLocale } from '@lib/types/datocms';
+import type {
+  InternalLinkFragment,
+  PageRecord,
+  SiteLocale,
+} from '@lib/types/datocms';
 import { getPagePath } from './index';
 
 interface Props {
@@ -15,23 +19,31 @@ const { locale } = Astro.params as Params;
 const { title, page } = link;
 
 // Determine pathname based on record type
-const getHref = (
-  { locale, page }: 
-    { locale: SiteLocale, page: InternalLinkFragment['page'] 
-  }) => {
+const getHref = ({
+  locale,
+  page,
+}: {
+  locale: SiteLocale;
+  page: InternalLinkFragment['page'];
+}) => {
   const pathParams = {
     HomePageRecord: [],
     PageRecord: [getPagePath({ page: page as PageRecord, locale })],
   }[page.__typename];
-  
-  return `/${[
-    locale,
-    ...pathParams,
-  ].filter(Boolean).join('/')}/`;
+
+  return `/${[locale, ...pathParams].filter(Boolean).join('/')}/`;
 };
 
 const href = getHref({ locale, page });
 const target = openInNewTab ? '_blank' : null;
+
+// Strip trailing spaces from slot contents so underlined links
+// do not extend further than the text.
+let html;
+if (Astro.slots.has('default')) {
+  html = await Astro.slots.render('default');
+  html = html.trim();
+}
 ---
 
-<a href={href} {target}><slot>{title}</slot></a>
+<a {href} {target}>{html ? <Fragment set:html={html} /> : title}</a>

--- a/src/components/StructuredText/Nodes/Link.astro
+++ b/src/components/StructuredText/Nodes/Link.astro
@@ -7,7 +7,19 @@ interface Props {
 
 const { node } = Astro.props;
 const { url, meta } = node;
-const targetBlank = Boolean(meta?.find(entry => entry.id === 'target' && entry.value === '_blank'));
+const targetBlank = Boolean(
+  meta?.find((entry) => entry.id === 'target' && entry.value === '_blank')
+);
+
+// Strip trailing spaces from slot contents so underlined links
+// do not extend further than the text.
+let html;
+if (Astro.slots.has('default')) {
+  html = await Astro.slots.render('default');
+  html = html.trim();
+}
 ---
 
-<a href={url} target={targetBlank ? '_blank' : null} rel="noopener noreferrer"><slot /></a>
+<a href={url} target={targetBlank ? '_blank' : null} rel="noopener noreferrer"
+><Fragment set:html={html} /></a
+>


### PR DESCRIPTION
# Changes

- Trims trailing whitespace from anchor (text) content. This prevents an underline from extending beyond the word boundary.


# How to test

1. Open preview link
2. Scroll to the hyperlinks example.
3. See that their link does not extend to the space after the last word.
4. Compare that with the current https://head-start.pages.dev/en/

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- ~~I have made updated relevant documentation files (in project README, docs/, etc)~~
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
