### PR TITLE
Fix: Astro imports in typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "typescript": "^5.2.2"
       },
       "devDependencies": {
+        "@astrojs/ts-plugin": "^1.10.2",
         "@datocms/cli": "^2.0.5",
         "@datocms/cma-client-node": "^2.0.0",
         "@graphql-codegen/cli": "^5.0.0",
@@ -323,9 +324,10 @@
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.8.0.tgz",
-      "integrity": "sha512-yrpD1WRGqsJwANaDIdtHo+YVjvIOFAjC83lu5qENIgrafwZcJgSXDuwVMXOgok4tFzpeKLsFQ6c3FoUdloLWBQ=="
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.10.3.tgz",
+      "integrity": "sha512-bL/O7YBxsFt55YHU021oL+xz+B/9HvGNId3F9xURN16aeqDK9juHGktdkCSXz+U4nqFACq6ZFvWomOzhV+zfPw==",
+      "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.4.0",
@@ -446,10 +448,78 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@astrojs/ts-plugin": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/ts-plugin/-/ts-plugin-1.10.2.tgz",
+      "integrity": "sha512-Q7EvUh9dU9Ufi6Jfe5JRcisBuremlLZ7jJImUY2/eMe6OVwCXSmETDir/tVwT0K+lnfNiUwju9qHZYX2/5ch0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.10.3",
+        "@astrojs/yaml2ts": "^0.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@volar/language-core": "~2.4.0",
+        "@volar/typescript": "~2.4.0",
+        "semver": "^7.3.8",
+        "vscode-languageserver-textdocument": "^1.0.11"
+      }
+    },
+    "node_modules/@astrojs/ts-plugin/node_modules/@volar/language-core": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.4.tgz",
+      "integrity": "sha512-kO9k4kTLfxpg+6lq7/KAIv3m2d62IHuCL6GbVgYZTpfKvIGoAIlDxK7pFcB/eczN2+ydg/vnyaeZ6SGyZrJw2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.4"
+      }
+    },
+    "node_modules/@astrojs/ts-plugin/node_modules/@volar/source-map": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.4.tgz",
+      "integrity": "sha512-xG3PZqOP2haG8XG4Pg3PD1UGDAdqZg24Ru8c/qYjYAnmcj6GBR64mstx+bZux5QOyRaJK+/lNM/RnpvBD3489g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@astrojs/ts-plugin/node_modules/@volar/typescript": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.4.tgz",
+      "integrity": "sha512-QQMQRVj0fVHJ3XdRKiS1LclhG0VBXdFYlyuHRQF/xLk2PuJuHNWP26MDZNvEVCvnyUQuUQhIAfylwY5TGPgc6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.4",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@astrojs/ts-plugin/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@astrojs/underscore-redirects": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-0.3.3.tgz",
       "integrity": "sha512-qDAKhFO4M1KzP7mxoJfiehf8oyf3EB158MxAa6z10NeD2pR3o4K3LlOQI8CfJgXE+BDBQcnaLvVCg/Mz/Gkg4Q=="
+    },
+    "node_modules/@astrojs/yaml2ts": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.1.tgz",
+      "integrity": "sha512-CBaNwDQJz20E5WxzQh4thLVfhB3JEEGz72wRA+oJp6fQR37QLAqXZJU0mHC+yqMOQ6oj0GfRPJrz6hjf+zm6zA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.5.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.24.7",
@@ -18892,10 +18962,14 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yaml": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
-      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
+      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
       "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
         "node": ">= 14"
       }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "typescript": "^5.2.2"
   },
   "devDependencies": {
+    "@astrojs/ts-plugin": "^1.10.2",
     "@datocms/cli": "^2.0.5",
     "@datocms/cma-client-node": "^2.0.0",
     "@graphql-codegen/cli": "^5.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,9 +10,14 @@
       "@lib/*": ["src/lib/*"],
       "@pages/*": ["src/pages/*"],
       "@root/*": ["./*"],
-      "@src/*": ["src/*"],
+      "@src/*": ["src/*"]
     },
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "plugins": [
+      {
+        "name": "@astrojs/ts-plugin"
+      }
+    ]
   },
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
# Changes

- Adds TS plugin for .astro files, so it won't be highlighted as an error.

# Associated issue

Resolves #175 

# How to test

<!-- example:
1. Open a non VSCode editor (best is to test in Zed)
2. Checkout branch
3. Run `npm ci`
4. Open a .ts file which imports an .astro file. For example src/components/Tabs/index.ts
5. Imports should not be highlighted as error.
-->

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- [x] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
