### PR TITLE
feature: LocaleSelector, use localised language names

### DIFF
--- a/src/components/LocaleSelector/LocaleSelector.astro
+++ b/src/components/LocaleSelector/LocaleSelector.astro
@@ -1,5 +1,5 @@
 ---
-import { getLocale, locales, t } from '@lib/i18n';
+import { getLocale, getLocaleName, locales, t } from '@lib/i18n';
 import type { SiteLocale } from '@lib/types/datocms';
 import type { PageUrl } from '@lib/seo';
 import '@assets/a11y.css';
@@ -7,7 +7,7 @@ import '@assets/a11y.css';
 const activeLocale = getLocale();
 
 interface Props {
-  pageUrls: PageUrl[],
+  pageUrls: PageUrl[];
 }
 const { pageUrls } = Astro.props;
 
@@ -15,26 +15,32 @@ const getPageHref = (locale: SiteLocale) => {
   const pageUrl = pageUrls.find((pageUrl) => pageUrl.locale === locale);
   return pageUrl
     ? new URL(pageUrl.pathname, Astro.site)
-    : new URL(`/${ locale }/`, Astro.site);
+    : new URL(`/${locale}/`, Astro.site);
 };
 ---
+
 <locale-selector>
   <nav aria-labelledby="locale-selector-title">
     <span id="locale-selector-title" class="a11y-sr-only">
-      { t('select_language') }
+      {t('select_language')}
     </span>
     <!-- [html-validate-disable-next no-redundant-role -- see ./README.md] -->
     <ul role="list" style="list-style: none;">
-      { locales.map(locale => (
-        <li>
-          <a hreflang={ locale }
-            href={ getPageHref(locale as SiteLocale) }
-            aria-current={ locale === activeLocale ? 'page' : 'false' }>
-            { /* tip: use @lib/i18n getLocaleName for locale names ('English', 'Deutsch', etc) */ }
-            { locale }
-          </a>
-        </li>
-      )) }
+      {
+        locales.map((locale) => (
+          <li>
+            <a
+              hreflang={locale}
+              href={getPageHref(locale as SiteLocale)}
+              lang={locale}
+              aria-current={locale === activeLocale ? 'page' : 'false'}
+              aria-label={getLocaleName(locale)}
+            >
+              <abbr title={getLocaleName(locale)}>{locale}</abbr>
+            </a>
+          </li>
+        ))
+      }
     </ul>
   </nav>
 </locale-selector>

--- a/src/components/LocaleSelector/README.md
+++ b/src/components/LocaleSelector/README.md
@@ -6,6 +6,7 @@
 
 * Component is a navigation element with a list of links `nav > ul > li > a`.
 * Navigation elements are advised to have [a heading `<h?>` and/or `[aria-labelledby]` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements#labeling_section_content) for accessibility.
+* Links use language codes (`<abbr>`) with [full name in their given language for accessibility](https://uxdesign.cc/designing-language-selectors-that-work-well-with-assistive-technology-c645a16e73e7). Each `<a>` tag therefore has an `[aria-label]` and a `[lang]` attribute. For example: `<a lang="nl" aria-label="Nederlands" ...>`.
 * Links to pages in alternate languages are advised to have an [`[hreflang]` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-hreflang).
 * Link for current page is advised to have an [`[aria-current="page"]` attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) for accessibility.
 * Lists require `[role="list"]` attribute when `list-style: none;` is applied to maintain accessibility in VoiceOver in Safari.

--- a/src/lib/i18n.test.ts
+++ b/src/lib/i18n.test.ts
@@ -80,8 +80,7 @@ describe('i18n:', () => {
   });
 
   test('"getLocaleName" should return a code instead of a name if locale is not supported', () => {
-    expect(getLocaleName('aa')).toBe('AA');
-    expect(getLocaleName('bb')).toBe('BB');
+    expect(getLocaleName('xx')).toBe('xx');
   });
 
   test('"t" should return translations', () => {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -33,21 +33,7 @@ export function setLocale(locale?: SiteLocale) {
 
 /**
  * Returns locale name for a given code in its own language.
- * This method only supports a few languages, to keep the bundle size small when used client-side.
- * To add more, see: https://github.com/adlawson/nodejs-langs/blob/master/data.js (not available in ESM)
  */
 export function getLocaleName(code: string) {
-  const localeNamesByCode = {
-    'de': 'Deutsch',
-    'en': 'English',
-    'es': 'Español',
-    'fr': 'Français',
-    'it': 'Italiano',
-    'nl': 'Nederlands',
-  };
-  const localeName = localeNamesByCode[code as keyof typeof localeNamesByCode];
-  if (localeName) {
-    return localeName;
-  }
-  return code.toUpperCase();
+  return new Intl.DisplayNames([code], { type: 'language' }).of(code);
 }


### PR DESCRIPTION
# Changes

Use localised language names in locale selector for enhanced accessiblity. "en" -> "English", "nl" -> "Nederlands".

# Associated issue

N/A

# How to test

1. Open preview link
2. Hover over locale selector items
3. Review the localised language names

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- ~~I have notified a reviewer~~

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
