### PR TITLE
feature: Remove background image when image is loaded

### DIFF
--- a/src/blocks/ImageBlock/Image.astro
+++ b/src/blocks/ImageBlock/Image.astro
@@ -27,39 +27,42 @@ const { image, loading = 'lazy' } = Astro.props;
 const altText = image.alt ? image.alt : ''; // default to empty string for accessibility
 const imageUnavailableMessage = t('image_unavailable');
 ---
+<enhanced-image>
+  <figure>
+    {
+      image.responsiveImage
+        ? // bitmap images have Imgix generated props (responsiveImage.*):
+        <img
+          alt={ altText }
+          loading={ loading }
+          srcset={ getImageSrcSet(image.url) }
+          src={ getImageSrc(image.url) }
+          style={{
+            aspectRatio: image.responsiveImage.aspectRatio,
+            backgroundImage: `url(${image.responsiveImage.base64})`
+          }}
+          data-unavailable={ imageUnavailableMessage }
+        />
+        : // vector images do not have Imgix generated props, so using as is:
+        <img
+          alt={ altText }
+          loading={ loading }
+          src={ image.url }
+          style={{
+            aspectRatio: `${image.width}/${image.height}`,
+          }}
+          data-unavailable={ imageUnavailableMessage }
+        />
+    }
+    { image.title && (
+      <figcaption>
+        { image.title }
+      </figcaption>
+    )}
+  </figure>
+</enhanced-image>
 
-<figure>
-  {
-    image.responsiveImage
-      ? // bitmap images have Imgix generated props (responsiveImage.*):
-      <img
-        alt={ altText }
-        loading={ loading }
-        srcset={ getImageSrcSet(image.url) }
-        src={ getImageSrc(image.url) }
-        style={{
-          aspectRatio: image.responsiveImage.aspectRatio,
-          backgroundImage: `url(${image.responsiveImage.base64})`
-        }}
-        data-unavailable={ imageUnavailableMessage }
-      />
-      : // vector images do not have Imgix generated props, so using as is:
-      <img 
-        alt={ altText }
-        loading={ loading }
-        src={ image.url } 
-        style={{
-          aspectRatio: `${image.width}/${image.height}`,
-        }}
-        data-unavailable={ imageUnavailableMessage }
-      />
-  }
-  { image.title && (
-    <figcaption>
-      { image.title }
-    </figcaption>
-  )}
-</figure>
+<script src="./Image.client.ts"></script>
 
 <style>
 /* functional styling */

--- a/src/blocks/ImageBlock/Image.astro
+++ b/src/blocks/ImageBlock/Image.astro
@@ -55,9 +55,7 @@ const imageUnavailableMessage = t('image_unavailable');
         />
     }
     { image.title && (
-      <figcaption>
-        { image.title }
-      </figcaption>
+      <figcaption>{ image.title }</figcaption>
     )}
   </figure>
 </image-block>

--- a/src/blocks/ImageBlock/Image.astro
+++ b/src/blocks/ImageBlock/Image.astro
@@ -27,7 +27,7 @@ const { image, loading = 'lazy' } = Astro.props;
 const altText = image.alt ? image.alt : ''; // default to empty string for accessibility
 const imageUnavailableMessage = t('image_unavailable');
 ---
-<enhanced-image>
+<image-block>
   <figure>
     {
       image.responsiveImage
@@ -60,7 +60,7 @@ const imageUnavailableMessage = t('image_unavailable');
       </figcaption>
     )}
   </figure>
-</enhanced-image>
+</image-block>
 
 <script src="./Image.client.ts"></script>
 

--- a/src/blocks/ImageBlock/Image.client.ts
+++ b/src/blocks/ImageBlock/Image.client.ts
@@ -1,4 +1,8 @@
-class EnhancedImage extends HTMLElement {
+/**
+ * A custom HTML element that enhances an `<img>` element with additional behavior.
+ * Automatically removes the inline `background-image` style once the image is fully loaded.
+ */
+class ImageBlock extends HTMLElement {
   imgElement: HTMLImageElement;
 
   handleImageLoad = (): void => {
@@ -24,4 +28,4 @@ class EnhancedImage extends HTMLElement {
   }
 }
 
-customElements.define('enhanced-image', EnhancedImage);
+customElements.define('image-block', ImageBlock);

--- a/src/blocks/ImageBlock/Image.client.ts
+++ b/src/blocks/ImageBlock/Image.client.ts
@@ -1,0 +1,50 @@
+/**
+ * A custom HTML element that enhances an `<img>` element with additional behavior.
+ * Automatically removes the inline `background-image` style once the image is fully loaded.
+ */
+class EnhancedImage extends HTMLElement {
+  /**
+   * The `img` element contained within this custom element.
+   */
+  imgElement: HTMLImageElement;
+
+  /**
+   * Handles the `load` event of the `imgElement`.
+   * Removes the `background-image` style from the `imgElement` and unregisters the event listener.
+   */
+  handleImageLoad = (): void => {
+    this.imgElement.style.removeProperty('background-image');
+    this.imgElement.removeEventListener('load', this.handleImageLoad);
+  };
+
+  /**
+   * Constructs the `EnhancedImage` element and initializes the `imgElement` property.
+   */
+  constructor() {
+    super();
+    this.imgElement = this.querySelector<HTMLImageElement>('img')!;
+  }
+
+  /**
+   * Called when the custom element is added to the DOM.
+   * Sets up the `load` event listener for the `imgElement` and immediately handles
+   * the `load` event if the image is already loaded.
+   */
+  connectedCallback(): void {
+    if (this.imgElement.complete) {
+      this.handleImageLoad();
+    } else {
+      this.imgElement.addEventListener('load', this.handleImageLoad);
+    }
+  }
+
+  /**
+   * Called when the custom element is removed from the DOM.
+   * Cleans up the `load` event listener to prevent memory leaks.
+   */
+  disconnectedCallback(): void {
+    this.imgElement.removeEventListener('load', this.handleImageLoad);
+  }
+}
+
+customElements.define('enhanced-image', EnhancedImage);

--- a/src/blocks/ImageBlock/Image.client.ts
+++ b/src/blocks/ImageBlock/Image.client.ts
@@ -1,35 +1,16 @@
-/**
- * A custom HTML element that enhances an `<img>` element with additional behavior.
- * Automatically removes the inline `background-image` style once the image is fully loaded.
- */
 class EnhancedImage extends HTMLElement {
-  /**
-   * The `img` element contained within this custom element.
-   */
   imgElement: HTMLImageElement;
 
-  /**
-   * Handles the `load` event of the `imgElement`.
-   * Removes the `background-image` style from the `imgElement` and unregisters the event listener.
-   */
   handleImageLoad = (): void => {
     this.imgElement.style.removeProperty('background-image');
     this.imgElement.removeEventListener('load', this.handleImageLoad);
   };
 
-  /**
-   * Constructs the `EnhancedImage` element and initializes the `imgElement` property.
-   */
   constructor() {
     super();
     this.imgElement = this.querySelector<HTMLImageElement>('img')!;
   }
 
-  /**
-   * Called when the custom element is added to the DOM.
-   * Sets up the `load` event listener for the `imgElement` and immediately handles
-   * the `load` event if the image is already loaded.
-   */
   connectedCallback(): void {
     if (this.imgElement.complete) {
       this.handleImageLoad();
@@ -38,10 +19,6 @@ class EnhancedImage extends HTMLElement {
     }
   }
 
-  /**
-   * Called when the custom element is removed from the DOM.
-   * Cleans up the `load` event listener to prevent memory leaks.
-   */
   disconnectedCallback(): void {
     this.imgElement.removeEventListener('load', this.handleImageLoad);
   }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,4 +1,3 @@
-/// <reference path="../.astro/types.d.ts" />
 /// <reference path="../.astro/env.d.ts" />
 type Runtime = import('@astrojs/cloudflare').Runtime<Env>;
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,3 +1,4 @@
+/// <reference path="../.astro/types.d.ts" />
 /// <reference path="../.astro/env.d.ts" />
 type Runtime = import('@astrojs/cloudflare').Runtime<Env>;
 


### PR DESCRIPTION
# Changes

- Adds a custom element with logic to remove the background image if image loads

# Associated issue

Resolves #132 

# How to test

1. Open preview link
2. Check in the inspector if images which are wrapped in an `enhanced-image` tag if they have a background image in the styles.
3. You can also go to your network tab and enable throttling to better see it happening (But with throttling the styles do not always seem to match with the real DOM, so you have te click the element away or try to disable the background image and you'll see it change and or cannot disable the rule).
 
# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- ~I have made updated relevant documentation files (in project README, docs/, etc)~
- ~I have added a decision log entry if the change affects the architecture or changes a significant technology~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
