### PR TITLE
Fix: Layout shifts caused by images

### DIFF
--- a/src/blocks/ImageBlock/Image.astro
+++ b/src/blocks/ImageBlock/Image.astro
@@ -37,6 +37,8 @@ const imageUnavailableMessage = t('image_unavailable');
           loading={ loading }
           srcset={ getImageSrcSet(image.url) }
           src={ getImageSrc(image.url) }
+          height={image.height}
+          width={image.width}
           style={{
             aspectRatio: image.responsiveImage.aspectRatio,
             backgroundImage: `url(${image.responsiveImage.base64})`
@@ -48,6 +50,8 @@ const imageUnavailableMessage = t('image_unavailable');
           alt={ altText }
           loading={ loading }
           src={ image.url }
+          height={image.height}
+          width={image.width}
           style={{
             aspectRatio: `${image.width}/${image.height}`,
           }}
@@ -67,6 +71,7 @@ const imageUnavailableMessage = t('image_unavailable');
 img {
   display: block;
   max-width: 100%;
+  height: auto;
   background-size: cover;
 }
 

--- a/src/blocks/ImageBlock/Image.astro
+++ b/src/blocks/ImageBlock/Image.astro
@@ -37,8 +37,6 @@ const imageUnavailableMessage = t('image_unavailable');
           loading={ loading }
           srcset={ getImageSrcSet(image.url) }
           src={ getImageSrc(image.url) }
-          height={image.height}
-          width={image.width}
           style={{
             aspectRatio: image.responsiveImage.aspectRatio,
             backgroundImage: `url(${image.responsiveImage.base64})`
@@ -50,8 +48,6 @@ const imageUnavailableMessage = t('image_unavailable');
           alt={ altText }
           loading={ loading }
           src={ image.url }
-          height={image.height}
-          width={image.width}
           style={{
             aspectRatio: `${image.width}/${image.height}`,
           }}
@@ -68,9 +64,14 @@ const imageUnavailableMessage = t('image_unavailable');
 
 <style>
 /* functional styling */
+figure {
+    max-width: 100%;
+    height: auto;
+}
+
 img {
   display: block;
-  max-width: 100%;
+  width: 100%;
   height: auto;
   background-size: cover;
 }

--- a/src/blocks/ImageBlock/Image.astro
+++ b/src/blocks/ImageBlock/Image.astro
@@ -37,8 +37,9 @@ const imageUnavailableMessage = t('image_unavailable');
           loading={ loading }
           srcset={ getImageSrcSet(image.url) }
           src={ getImageSrc(image.url) }
+          width={ image.width }
+          height={ image.height }
           style={{
-            aspectRatio: image.responsiveImage.aspectRatio,
             backgroundImage: `url(${image.responsiveImage.base64})`
           }}
           data-unavailable={ imageUnavailableMessage }
@@ -48,9 +49,8 @@ const imageUnavailableMessage = t('image_unavailable');
           alt={ altText }
           loading={ loading }
           src={ image.url }
-          style={{
-            aspectRatio: `${image.width}/${image.height}`,
-          }}
+          width={ image.width }
+          height={ image.height }
           data-unavailable={ imageUnavailableMessage }
         />
     }
@@ -64,14 +64,10 @@ const imageUnavailableMessage = t('image_unavailable');
 
 <style>
 /* functional styling */
-figure {
-    max-width: 100%;
-    height: auto;
-}
 
 img {
   display: block;
-  width: 100%;
+  max-width: 100%;
   height: auto;
   background-size: cover;
 }

--- a/src/blocks/ImageBlock/ImageBlock.fragment.graphql
+++ b/src/blocks/ImageBlock/ImageBlock.fragment.graphql
@@ -7,7 +7,6 @@ fragment ImageBlock on ImageBlockRecord {
     height
     url
     responsiveImage {
-      aspectRatio
       base64
     }
   }

--- a/src/blocks/ImageBlock/ImageBlock.test.ts
+++ b/src/blocks/ImageBlock/ImageBlock.test.ts
@@ -25,7 +25,7 @@ describe('ImageBlock', () => {
     expect(img?.getAttribute('loading')).toBe('lazy');
   });
 
-  test('renders the correct aspect ratio style', async () => {
+  test('renders the correct width and height', async () => {
     const fragment = await renderToFragment<Props>(ImageBlock, {
       props: {
         block: {
@@ -41,7 +41,8 @@ describe('ImageBlock', () => {
     });
 
     const img = fragment.querySelector('img');
-    expect(img?.style.aspectRatio).toBe('150/150');
+    expect(img?.width).toBe(150);
+    expect(img?.height).toBe(150);
   });
 
   test('renders with a figcaption when title is provided', async () => {
@@ -90,8 +91,9 @@ describe('ImageBlock', () => {
           image: {
             url: 'https://example.com/test.jpg',
             alt: 'A responsive test image',
+            height: 150,
+            width: 150,
             responsiveImage: {
-              aspectRatio: 1.9526315789473685,
               base64: 'data:image/jpeg;base64,...'
             }
           }
@@ -100,7 +102,8 @@ describe('ImageBlock', () => {
     });
 
     const img = fragment.querySelector('img');
-    expect(img?.style.aspectRatio).toBe('1.9526315789473685');
+    expect(img?.width).toBe(150);
+    expect(img?.height).toBe(150);
     expect(img?.style.backgroundImage).toContain('base64');
   });
 });


### PR DESCRIPTION
# Changes

- Fixes layout shifts by setting width and height on images

# Associated issue

Issue seen and fixed in Happy Labs.

# How to test

1. Open preview link in English
2. Open inspector
3. Go to network tab
4. Enable `ignore cache` and set network throttling on
5. You'll see the image size being reserved.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- ~I have made updated relevant documentation files (in project README, docs/, etc)~
- ~I have added a decision log entry if the change affects the architecture or changes a significant technology~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
