### PR TITLE
fix(env): do not use getSecret but import env variables directly since getSecret is broken

### DIFF
--- a/config/preview.ts
+++ b/config/preview.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 
-export const previewBranches = ['preview', 'feat/preview-mode', 'fix/function-size', 'fix/preview-mode-routing', 'preview-throws-500-due-to-Astro-bug-in-server-mode'];
+export const previewBranches = ['preview', 'feat/preview-mode', 'fix/function-size', 'fix/preview-mode-routing', 'preview-throws-500-due-to-Astro-bug-in-server-mode', 'fix/previews-not-working'];
 
 function getGitBranch() {
   const branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim();

--- a/src/lib/datocms.ts
+++ b/src/lib/datocms.ts
@@ -4,7 +4,7 @@ import type { DocumentNode } from 'graphql';
 import type { SiteLocale } from '@lib/i18n.types';
 import { titleSuffix } from './seo';
 import { datocmsBuildTriggerId, datocmsEnvironment } from '../../datocms-environment';
-import { getSecret } from 'astro:env/server';
+import { DATOCMS_READONLY_API_TOKEN, HEAD_START_PREVIEW } from 'astro:env/server';
 
 const wait = (milliSeconds: number) => new Promise((resolve) => setTimeout(resolve, milliSeconds));
 
@@ -20,12 +20,12 @@ type DatocmsRequest = {
  */
 export const datocmsRequest = async <T>({ query, variables = {}, retryCount = 1 }: DatocmsRequest): Promise<T> => {
   const headers = new Headers({
-    Authorization: getSecret('DATOCMS_READONLY_API_TOKEN')!,
+    Authorization: DATOCMS_READONLY_API_TOKEN,
     'Content-Type': 'application/json',
     'X-Environment': datocmsEnvironment,
     'X-Exclude-Invalid': 'true', // https://www.datocms.com/docs/content-delivery-api/api-endpoints#strict-mode-for-non-nullable-graphql-types
   });
-  if (getSecret('HEAD_START_PREVIEW')) {
+  if (HEAD_START_PREVIEW) {
     headers.append('X-Include-Drafts', 'true');
   }
 
@@ -168,7 +168,7 @@ export const datocmsSearch = async({ locale, query, fuzzy = true }: { locale: Si
 
   const response = await fetch(url.toString(), {
     headers: {
-      'Authorization': `Bearer ${getSecret('DATOCMS_READONLY_API_TOKEN')}`,
+      'Authorization': `Bearer ${DATOCMS_READONLY_API_TOKEN}`,
       'Accept': 'application/json',
       'X-Api-Version': '3',
     },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,7 @@ import { defaultLocale, locales, setLocale } from './lib/i18n';
 import type { SiteLocale } from '@lib/i18n.types';
 import { getRedirectTarget } from '@lib/routing/redirects';
 import { datocmsEnvironment } from '@root/datocms-environment';
-import { getSecret } from 'astro:env/server';
+import { DATOCMS_READONLY_API_TOKEN, HEAD_START_PREVIEW_SECRET, HEAD_START_PREVIEW } from 'astro:env/server';
 
 export const previewCookieName = 'HEAD_START_PREVIEW';
 
@@ -17,7 +17,7 @@ export const hashSecret = async (secret: string) => {
 export const datocms = defineMiddleware(async ({ locals }, next) => {
   Object.assign(locals, {
     datocmsEnvironment,
-    datocmsToken: getSecret('DATOCMS_READONLY_API_TOKEN')
+    datocmsToken: DATOCMS_READONLY_API_TOKEN
   });
   const response = await next();
   return response;
@@ -40,9 +40,9 @@ const i18n = defineMiddleware(async ({ params, request }, next) => {
 });
 
 const preview = defineMiddleware(async ({ cookies, locals }, next) => {
-  const previewSecret = getSecret('HEAD_START_PREVIEW_SECRET')!;
+  const previewSecret = HEAD_START_PREVIEW_SECRET!;
   Object.assign(locals, {
-    isPreview: getSecret('HEAD_START_PREVIEW'),
+    isPreview: HEAD_START_PREVIEW,
     isPreviewAuthOk: Boolean(previewSecret) && cookies.get(previewCookieName)?.value === await hashSecret(previewSecret),
     previewSecret
   });


### PR DESCRIPTION
It appears getSecret is broken when used on env variables that are not defined in the .env file. Thus breaking previews in our case. I replaced all getSecret references and directly imported the variables from astro:env/server, which is also possible according to https://docs.astro.build/en/reference/configuration-reference/#experimentalenv. Note that what they write there about getSecret didnt work!

Both urls below should either show you a login screen or should show you the "In preview mode banner":

So main doesnt work, see https://preview.head-start.pages.dev/en/
The PR preview does work: https://fix-previews-not-working.head-start.pages.dev/en/
