### PR TITLE
test: SEO lib helpers

### DIFF
--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -45,7 +45,7 @@ const mainContentId = 'content';
       <SkipLink targetId={ mainContentId } />
       <header { ...datocmsNoIndex }>
         { /* accessible home link, inspired by https://www.gov.uk/; with Microformats rel */ }
-        <a rel="home" href={ getHomeHref() } aria-label={ t('go_to_home_page', { siteName }) }>[Logo]</a>
+        <a rel="home" href={ getHomeHref() } aria-label={ t('go_to_home_page', { siteName: siteName() }) }>[Logo]</a>
         <div>
           <LocaleSelector pageUrls={ pageUrls } />
           <a rel="search" href={ getSearchPathname(locale) }>{ t('search') }</a>

--- a/src/lib/datocms/index.ts
+++ b/src/lib/datocms/index.ts
@@ -151,7 +151,7 @@ export const formatSearchResults = ({ query, results }: { query: string, results
     const textFragmentUrl = `${url}#:~:${ matches.map(({ matchingTerm }) => `text=${encodeURIComponent(matchingTerm)}`).join('&')}`;
 
     return {
-      title: title.replace(new RegExp(`${titleSuffix}$`), '').trim(),
+      title: title.replace(new RegExp(`${titleSuffix()}$`), '').trim(),
       matches: matches.length ? matches : [defaultMatch],
       score,
       pathname,

--- a/src/lib/seo/index.test.ts
+++ b/src/lib/seo/index.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, test, expect, vi } from 'vitest';
+import { siteName, titleSuffix, titleTag, } from '@lib/seo';
+import { getLocale } from '@lib/i18n';
+
+vi.mock('@lib/i18n', () => ({
+  getLocale: vi.fn(),
+}));
+
+vi.mock('@lib/site.json', () => ({
+  globalSeo: {
+    en: {
+      siteName: 'Test Site (English)',
+      titleSuffix: '| English Site',
+    },
+    nl: {
+      siteName: 'Test Site (Dutch)',
+      titleSuffix: '| Nederlandse Site',
+    },
+  },
+}));
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.restoreAllMocks();
+});
+
+describe('seo', () => {
+  test('siteName is correctly set for different locales', () => {
+    vi.mocked(getLocale).mockReturnValue('en');
+    expect(siteName()).toBe('Test Site (English)');
+
+    vi.mocked(getLocale).mockReturnValue('nl');
+    expect(siteName()).toBe('Test Site (Dutch)');
+  });
+
+  test('titleSuffix is correctly set for different locales', () => {
+    vi.mocked(getLocale).mockReturnValue('en');
+    expect(titleSuffix()).toBe('| English Site');
+
+    vi.mocked(getLocale).mockReturnValue('nl');
+    expect(titleSuffix()).toBe('| Nederlandse Site');
+  });
+
+  test('titleTag generates correct title for different locales', () => {
+    vi.mocked(getLocale).mockReturnValue('en');
+    expect(titleTag('Test Page')).toEqual({
+      tag: 'title',
+      content: 'Test Page | English Site',
+    });
+
+    vi.mocked(getLocale).mockReturnValue('nl');
+    expect(titleTag('Testpagina')).toEqual({
+      tag: 'title',
+      content: 'Testpagina | Nederlandse Site',
+    });
+  });
+});

--- a/src/lib/seo/index.ts
+++ b/src/lib/seo/index.ts
@@ -8,10 +8,19 @@ export type PageUrl = {
   pathname: string,
 };
 
-const locale = getLocale();
+export const siteName = () => {
+  const locale = getLocale();
+  const localeSeo = globalSeo[locale as keyof typeof globalSeo];
 
-export const siteName = globalSeo[locale as keyof typeof globalSeo].siteName;
-export const titleSuffix = globalSeo[locale as keyof typeof globalSeo].titleSuffix;
+  return localeSeo.siteName;
+};
+
+export const titleSuffix = () => {
+  const locale = getLocale();
+  const localeSeo = globalSeo[locale as keyof typeof globalSeo];
+
+  return localeSeo.titleSuffix;
+};
 
 export const noIndexTag: Tag = {
   attributes: { name: 'robots' },
@@ -19,7 +28,7 @@ export const noIndexTag: Tag = {
   tag: 'meta',
 };
 
-export const titleTag = (title:string): Tag => ({
+export const titleTag = (title: string): Tag => ({
   tag: 'title',
-  content: `${title} ${titleSuffix}`,
+  content: `${title} ${titleSuffix()}`,
 });

--- a/src/pages/[locale]/search/index.astro
+++ b/src/pages/[locale]/search/index.astro
@@ -14,7 +14,7 @@ const { locale } = Astro.params as { locale: SiteLocale };
 const query = new URL(Astro.request.url).searchParams.get(queryParamName) || '';
 const { results } = hasValidQuery(query) ? await datocmsSearch({ locale, query }) : { results: [] };
 const hasResults = results.length > 0;
-const pageTitle = t('search_on_site', { siteName });
+const pageTitle = t('search_on_site', { siteName: siteName() });
 const getPathWithQuery = (locale: SiteLocale) => getSearchPathname(locale) + (query ? `?${queryParamName}=${query}` : '');
 const pageUrls = locales.map(locale => ({ locale, pathname: getPathWithQuery(locale) }));
 const breadcrumbs = [


### PR DESCRIPTION
# Changes

<!-- example:
- Fixes wrong color in button
- Adds a new page
-->

- modified `siteName` and `titleSuffix` seo lib getters to be functions so they always use the locale from the moment they functions are invoked (instead of using the locale from the moment the file is first executed)
- add unit tests for seo lib function

# Associated issue

<!-- example:
Resolves #(ticket number)
-->

- n/a

# How to test

<!-- example:
1. Open preview link
2. Navigate to ...
3. Tap on ...
4. Verify that ...
5. Etc ...
-->

- run `npm run test:unit` -- this also happens automatically so you could also just check if the associated pipeline succeeds

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- [x] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
