### PR TITLE
feature: link to files (for download)

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -54,7 +54,6 @@ export default defineConfig({
   output: isPreview ? 'server' : 'static',
   server: { port: localhostPort },
   site: siteUrl,
-  trailingSlash: 'always',
   vite: {
     plugins: [
       graphql() as PluginOption,

--- a/config/datocms/migrations/1730927867_fileModel.ts
+++ b/config/datocms/migrations/1730927867_fileModel.ts
@@ -1,0 +1,169 @@
+import { Client } from '@datocms/cli/lib/cma-client-node';
+
+export default async function (client: Client) {
+  console.log('Manage upload filters');
+
+  console.log('Install plugin "Computed Fields"');
+  await client.plugins.create({
+    id: 'EiyZ3d0SSDCPCNbsKBIwWQ',
+    package_name: 'datocms-plugin-computed-fields',
+  });
+  await client.plugins.update('EiyZ3d0SSDCPCNbsKBIwWQ', {
+    parameters: { migratedFromLegacyPlugin: true },
+  });
+
+  console.log('Create new models/block models');
+
+  console.log('Create model "\uD83D\uDCE6 File" (`file`)');
+  await client.itemTypes.create(
+    {
+      id: 'GjWw8t-hTFaYYWyc53FeIg',
+      name: '\uD83D\uDCE6 File',
+      api_key: 'file',
+      collection_appearance: 'table',
+      inverse_relationships_enabled: true,
+    },
+    {
+      skip_menu_item_creation: true,
+      schema_menu_item_id: 'Q7zpH-QAQJ2XBI2CcBio5w',
+    }
+  );
+
+  console.log('Creating new fields/fieldsets');
+
+  console.log(
+    'Create Single asset field "File" (`file`) in model "\uD83D\uDCE6 File" (`file`)'
+  );
+  await client.fields.create('GjWw8t-hTFaYYWyc53FeIg', {
+    id: 'LolhguizT_mZMl1zzZtQ4Q',
+    label: 'File',
+    field_type: 'file',
+    api_key: 'file',
+    validators: { required: {} },
+    appearance: { addons: [], editor: 'file', parameters: {} },
+    default_value: null,
+  });
+
+  console.log(
+    'Create Single-line string field "Locale" (`locale`) in model "\uD83D\uDCE6 File" (`file`)'
+  );
+  await client.fields.create('GjWw8t-hTFaYYWyc53FeIg', {
+    id: 'JcOc0SI4RYONRdiNvys1Rg',
+    label: 'Locale',
+    field_type: 'string',
+    api_key: 'locale',
+    hint: 'Only relevant for files containing text.',
+    appearance: {
+      addons: [],
+      editor: 'string_select',
+      parameters: {
+        options: [
+          { hint: '', label: 'Deutsch', value: 'de' },
+          { hint: '', label: 'English', value: 'en' },
+          { hint: '', label: 'Espa\u00F1ol', value: 'es' },
+          { hint: '', label: 'Fran\u00E7ais', value: 'fr' },
+          { hint: '', label: 'Italiano', value: 'it' },
+          { hint: '', label: 'Nederlands', value: 'nl' },
+        ],
+      },
+    },
+    default_value: '',
+  });
+
+  console.log(
+    'Create Single-line string field "Title" (`title`) in model "\uD83D\uDCE6 File" (`file`)'
+  );
+  await client.fields.create('GjWw8t-hTFaYYWyc53FeIg', {
+    id: 'YIftd04cTlyz0aEvqsfWXA',
+    label: 'Title',
+    field_type: 'string',
+    api_key: 'title',
+    hint: 'This title is automatically generated based on the filename of the selected file. This ensures you can recognise this record in overviews and when inserting it in a text field.',
+    validators: { required: {} },
+    appearance: {
+      addons: [],
+      editor: 'EiyZ3d0SSDCPCNbsKBIwWQ',
+      parameters: {
+        defaultFunction:
+          'const upload = await getUpload(file.upload_id)\nreturn `${upload.filename}`',
+      },
+      field_extension: 'computedFields',
+    },
+    default_value: '',
+  });
+
+  console.log('Update existing fields/fieldsets');
+
+  console.log(
+    'Update Structured text field "Text" (`text`) in block model "\uD83D\uDCDD \uD83D\uDDBC\uFE0F Text Image Block" (`text_image_block`)'
+  );
+  await client.fields.update('V4dMfrWsQ027JYEp6q3KhA', {
+    validators: {
+      required: {},
+      structured_text_blocks: {
+        item_types: [
+          'ZdBokLsWRgKKjHrKeJzdpw',
+          'gezG9nO7SfaiWcWnp-HNqw',
+          '0SxYNS2CR1it_5LHYWuEQg',
+        ],
+      },
+      structured_text_links: {
+        on_publish_with_unpublished_references_strategy: 'fail',
+        on_reference_unpublish_strategy: 'delete_references',
+        on_reference_delete_strategy: 'delete_references',
+        item_types: [
+          'GjWw8t-hTFaYYWyc53FeIg',
+          'LjXdkuCdQxCFT4hv8_ayew',
+          'X_tZn3TxQY28ltSyjZUGHQ',
+        ],
+      },
+    },
+  });
+
+  console.log(
+    'Update Structured text field "Text" (`text`) in block model "\uD83D\uDCDD Text Block" (`text_block`)'
+  );
+  await client.fields.update('NtVXfZ6gTL2sKNffNeUf5Q', {
+    validators: {
+      required: {},
+      structured_text_blocks: {
+        item_types: [
+          'QYfZyBzIRWKxA1MinIR0aQ',
+          'ZdBokLsWRgKKjHrKeJzdpw',
+          'gezG9nO7SfaiWcWnp-HNqw',
+          '0SxYNS2CR1it_5LHYWuEQg',
+        ],
+      },
+      structured_text_links: {
+        on_publish_with_unpublished_references_strategy: 'fail',
+        on_reference_unpublish_strategy: 'delete_references',
+        on_reference_delete_strategy: 'delete_references',
+        item_types: [
+          'GjWw8t-hTFaYYWyc53FeIg',
+          'LjXdkuCdQxCFT4hv8_ayew',
+          'X_tZn3TxQY28ltSyjZUGHQ',
+        ],
+      },
+    },
+  });
+
+  console.log('Finalize models/block models');
+
+  console.log('Update model "\uD83D\uDCE6 File" (`file`)');
+  await client.itemTypes.update('GjWw8t-hTFaYYWyc53FeIg', {
+    title_field: { id: 'YIftd04cTlyz0aEvqsfWXA', type: 'field' },
+    image_preview_field: { id: 'LolhguizT_mZMl1zzZtQ4Q', type: 'field' },
+  });
+
+  console.log('Manage menu items');
+
+  console.log('Create menu item "\uD83D\uDCE6 Files"');
+  await client.menuItems.create({
+    id: 'P1lE98ITSp-2unhby2N59g',
+    label: '\uD83D\uDCE6 Files',
+    item_type: { id: 'GjWw8t-hTFaYYWyc53FeIg', type: 'item_type' },
+  });
+
+  console.log('Update menu item "\uD83D\uDCE6 Files"');
+  await client.menuItems.update('P1lE98ITSp-2unhby2N59g', { position: 5 });
+}

--- a/datocms-environment.ts
+++ b/datocms-environment.ts
@@ -3,5 +3,5 @@
  * @see docs/getting-started.md on how to use this file
  * @see docs/decision-log/2023-10-24-datocms-env-file.md on why file is preferred over env vars
  */
-export const datocmsEnvironment = '160-link-records';
+export const datocmsEnvironment = '148-file-downloads';
 export const datocmsBuildTriggerId = '30535';

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "jiti": "^1.20.0",
         "nanostores": "^0.9.5",
         "oembed-providers": "^1.0.20230906",
+        "pretty-bytes": "^6.1.1",
         "promise-all-props": "^3.0.0",
         "regexparam": "^3.0.0",
         "rosetta": "^1.1.0",
@@ -15707,6 +15708,17 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
+      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "jiti": "^1.20.0",
     "nanostores": "^0.9.5",
     "oembed-providers": "^1.0.20230906",
+    "pretty-bytes": "^6.1.1",
     "promise-all-props": "^3.0.0",
     "regexparam": "^3.0.0",
     "rosetta": "^1.1.0",

--- a/src/assets/icons/download.svg
+++ b/src/assets/icons/download.svg
@@ -1,0 +1,2 @@
+<!-- source: https://icon-sets.iconify.design/grommet-icons/download/ -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="2" d="M1 17v6h22v-6M12 2v17m-7-7l7 7l7-7"/></svg>

--- a/src/blocks/TextBlock/TextBlock.fragment.graphql
+++ b/src/blocks/TextBlock/TextBlock.fragment.graphql
@@ -2,6 +2,7 @@
 #import '@blocks/TableBlock/TableBlock.fragment.graphql'
 #import '@blocks/VideoBlock/VideoBlock.fragment.graphql'
 #import '@blocks/VideoEmbedBlock/VideoEmbedBlock.fragment.graphql'
+#import '@lib/routing/FileRoute.fragment.graphql'
 #import '@lib/routing/HomeRoute.fragment.graphql'
 #import '@lib/routing/PageRoute.fragment.graphql'
 
@@ -24,6 +25,9 @@ fragment TextBlock on TextBlockRecord {
     }
     links {
       __typename
+      ... on FileRecord {
+        ...FileRoute
+      }
       ... on HomePageRecord {
         ...HomeRoute
       }

--- a/src/blocks/TextImageBlock/TextImageBlock.fragment.graphql
+++ b/src/blocks/TextImageBlock/TextImageBlock.fragment.graphql
@@ -1,6 +1,7 @@
 #import '@blocks/ImageBlock/ImageBlock.fragment.graphql'
 #import '@blocks/TableBlock/TableBlock.fragment.graphql'
 #import '@blocks/VideoEmbedBlock/VideoEmbedBlock.fragment.graphql'
+#import '@lib/routing/FileRoute.fragment.graphql'
 #import '@lib/routing/HomeRoute.fragment.graphql'
 #import '@lib/routing/PageRoute.fragment.graphql'
 
@@ -20,6 +21,9 @@ fragment TextImageBlock on TextImageBlockRecord {
     }
     links {
       __typename
+      ... on FileRecord {
+        ...FileRoute
+      }
       ... on HomePageRecord {
         ...HomeRoute
       }

--- a/src/components/LinkToFile/LinkToFile.astro
+++ b/src/components/LinkToFile/LinkToFile.astro
@@ -4,7 +4,8 @@ import prettyBytes from 'pretty-bytes';
 import { getLocale } from '@lib/i18n';
 import { getFileHref } from '@lib/routing/';
 import Icon from '@components/Icon';
-type Props = {
+
+export type Props = {
   record: FileRouteFragment;
 };
 const { record, ...props } = Astro.props;

--- a/src/components/LinkToFile/LinkToFile.astro
+++ b/src/components/LinkToFile/LinkToFile.astro
@@ -1,0 +1,43 @@
+---
+import type { FileRouteFragment } from '@lib/types/datocms';
+import prettyBytes from 'pretty-bytes';
+import { getLocale } from '@lib/i18n';
+import { getFileHref } from '@lib/routing/';
+import Icon from '@components/Icon';
+type Props = {
+  record: FileRouteFragment;
+};
+const { record, ...props } = Astro.props;
+const { file, locale: fileLocale, title } = record;
+const pageLocale = getLocale();
+const localeText =
+  fileLocale && fileLocale !== pageLocale
+    ? new Intl.DisplayNames([pageLocale], { type: 'language' }).of(fileLocale)
+    : '';
+const format = file.format.toUpperCase();
+const size = prettyBytes(file.size, { locale: pageLocale });
+const metaText = [localeText, format, size].filter(Boolean).join(', ');
+---
+
+<a
+  href={getFileHref(record)}
+  hreflang={fileLocale}
+  download={title}
+  type={file.mimeType}
+  {...props}
+>
+  <span class="title"><slot>{title}</slot></span>
+  ({metaText})
+  <Icon class="icon" name="download" /></a
+>
+
+<style>
+  /* Underline only the title, so the meta data doesn't obscure the link visually, 
+     but is still part of the link content for assistive technology */
+  a {
+    display: contents;
+  }
+  .title {
+    text-decoration: inherit;
+  }
+</style>

--- a/src/components/LinkToFile/LinkToFile.astro
+++ b/src/components/LinkToFile/LinkToFile.astro
@@ -1,5 +1,5 @@
 ---
-import type { FileRouteFragment } from '@lib/types/datocms';
+import type { FileRouteFragment } from '@lib/datocms/types';
 import prettyBytes from 'pretty-bytes';
 import { getLocale } from '@lib/i18n';
 import { getFileHref } from '@lib/routing/';

--- a/src/components/LinkToFile/LinkToFile.test.ts
+++ b/src/components/LinkToFile/LinkToFile.test.ts
@@ -1,9 +1,27 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, } from 'vitest';
 import { datocmsAssetsOrigin } from '@lib/datocms';
 import { renderToFragment } from '@lib/renderer';
 import LinkToFile, { type Props as LinkToFileProps } from './LinkToFile.astro';
+import { getLocale } from '@lib/i18n';
 
-const mockFileLinkProps = ({ basename }: { basename: string }) => {
+type MockFileOptions = {
+  basename?: string;
+  format?: string;
+  size?: number;
+  locale?: string | null;
+}
+
+const mockFilename = (basename: string) => `123-${basename}`;
+const mockFilePath = (basename: string) => `/path/to/${mockFilename(basename)}`;
+
+const mockFileLinkProps = ({ 
+  basename = 'example.pdf', 
+  format = 'pdf', 
+  size = 123456, 
+  locale 
+}: MockFileOptions) => {
+  const filename = mockFilename(basename);
+  const proxiedFilePath = mockFilePath(basename);
   return {
     record: { 
       __typename: 'FileRecord',
@@ -11,52 +29,119 @@ const mockFileLinkProps = ({ basename }: { basename: string }) => {
       title: basename,
       file: { 
         basename: basename,
-        filename: `123-${basename}`,
-        format: 'pdf',
-        mimeType: 'application/pdf',
-        size: 123456,
-        url: new URL(`/path/to/123-${basename}`, datocmsAssetsOrigin).toString(),
+        filename: filename,
+        format: format,
+        mimeType: `application/${format}`,
+        size: size,
+        url: new URL(`${proxiedFilePath}`, datocmsAssetsOrigin).toString(),
       },
+      locale: locale || null,
     }
-  } as LinkToFileProps;
+  } satisfies LinkToFileProps;
 };
 
 describe('LinkToFile', async () => {
-  const pdfProps = mockFileLinkProps({ basename: 'example.pdf' });
-  const pdfLink = await renderToFragment<LinkToFileProps>(LinkToFile, { props: pdfProps });
-  // todo: add another example file docx?
-
+  const sizes = [
+    { size: 123, expected: '123 B' },
+    { size: 123456, expected: '123 kB' },
+    { size: 12345678, expected: '12.3 MB' },
+  ];
+  const fileScenariosProps = ([
+    { basename: 'example.docx', format: 'docx', size: sizes[0].size },
+    { basename: 'example.pdf', format: 'pdf', size: sizes[0].size  },
+    { basename: 'example.zip', format: 'zip', size: sizes[0].size  },
+  ] as const).map(mockFileLinkProps);
+  const fileScenarios = await Promise.all(fileScenariosProps
+    .map(async (props) =>renderToFragment<LinkToFileProps>(LinkToFile, { props }))
+  );
+  
   test('renders as a link to proxied file url', () => {
-    expect(pdfLink.querySelector('a')?.getAttribute('href')).toBe('/files/path/to/123-example.pdf');
+    fileScenarios.forEach((component, index) => {
+      const basename = fileScenariosProps[index].record.file.basename;
+      expect(component.querySelector('a')?.getAttribute('href')).toBe(`/files${mockFilePath(basename)}`);
+    });
   });
 
   test('uses the record title as the link text', () => {
-    expect(pdfLink.querySelector('a')?.textContent).toContain(pdfProps.record.title);
+    fileScenarios.forEach((component, index) => {
+      const title = fileScenariosProps[index].record.title;
+      expect(component.querySelector('a')?.textContent).toContain(title);
+    });
   });
 
   test('uses the file\'s basename as [download] value', () => {
-    expect(pdfLink.querySelector('a')?.getAttribute('download')).toBe('example.pdf');
+    fileScenarios.forEach((component, index) => {
+      const basename = fileScenariosProps[index].record.file.basename;
+      expect(component.querySelector('a')?.getAttribute('download')).toBe(basename);
+    });
   });
 
   test('uses the file\'s mimetype as [type] value',  () => {
-    expect(pdfLink.querySelector('a')?.getAttribute('type')).toBe('application/pdf');
+    fileScenarios.forEach((component, index) => {
+      const mimeType = fileScenariosProps[index].record.file.mimeType;
+      expect(component.querySelector('a')?.getAttribute('type')).toBe(mimeType);
+    });
   });
+  
+  const linkMetaRegex = new RegExp(/\(.+\)$/m);
 
   test('includes file meta between brackets', () => {
-    expect(pdfLink.querySelector('a')?.textContent).toMatch(/\(.+\)/);
+    fileScenarios.forEach((component) => {
+      const linkMeta = component.querySelector('a')?.textContent?.match(linkMetaRegex)?.[0] || '';
+      expect(linkMeta).toMatch(linkMetaRegex);
+    });
   });
 
   test('renders the file\'s format capitalised as meta data', () => {
-    // todo: check if format is actually between brackets? extract meta text first?
-    expect(pdfLink.querySelector('a')?.textContent).toContain(pdfProps.record.file.format.toUpperCase());
+    fileScenarios.forEach((component, index) => {
+      const format = fileScenariosProps[index].record.file.format;
+      const linkMeta = component.querySelector('a')?.textContent?.match(linkMetaRegex)?.[0] || '';
+      expect(linkMeta).toContain(format.toUpperCase());
+    });
   });
 
-  test('renders the filesize as meta data in human readable format', () => {
-    // todo: check if format is actually between brackets? extract meta text first?
-    // todo: different file sizes?
-    expect(pdfLink.querySelector('a')?.textContent).toContain('123 kB');
-  });
+  test('renders the filesize as meta data in human readable format', async () => {
+    const sizeScenariosProps = sizes.map(({ size }) => mockFileLinkProps({ size }));
+    const sizeScenarios = await Promise.all(sizeScenariosProps
+      .map(async (props) =>renderToFragment<LinkToFileProps>(LinkToFile, { props }))
+    );
 
-  // test hreflang
-  // test locale between brackets if ... (French), (Frans) (mock locale?)
+    sizeScenarios.forEach((component, index) => {
+      const { expected } = sizes[index];
+      const linkMeta = component.querySelector('a')?.textContent?.match(linkMetaRegex)?.[0] || '';
+      expect(linkMeta).toContain(expected);
+    });
+  });
+  
+  test('renders no human-readable hreflang when it matches current locale', async () => {
+    const locale = getLocale();
+    const props = mockFileLinkProps({ locale });
+    const { format, size: filesize } = props.record.file;
+    const expectedFormatMeta = format.toUpperCase();
+    const expectedSizeMeta = sizes.find(({ size }) => filesize === size)?.expected;
+    const component = await renderToFragment<LinkToFileProps>(LinkToFile, { props });
+    const linkMeta = component.querySelector('a')?.textContent?.match(linkMetaRegex)?.[0] || '';
+    // Hard to prove a negative, but we can check the string matches only other data
+    const expected = `(${expectedFormatMeta}, ${expectedSizeMeta})`;
+    expect(linkMeta).toMatch(expected);
+  });
+  
+  test('renders the hreflang as meta data in human-readable format ', async () => {
+    const locales: { locale: string, expected: Record<string, string> }[] = [
+      { locale: 'en', expected: { nl: 'Engels' } },
+      { locale: 'nl', expected: { en: 'Dutch' } },
+    ];
+    const localeScenariosProps = locales.map(({ locale }) => mockFileLinkProps({ locale }));
+    const localeScenarios = await Promise.all(localeScenariosProps
+      .map(async (props) =>renderToFragment<LinkToFileProps>(LinkToFile, { props }))
+    );
+
+    localeScenarios.forEach((component, index) => {
+      const { locale: fileLocale, expected } = locales[index];
+      const contextLocale = getLocale();
+      if (fileLocale === contextLocale) return; // No need to test this, as it's already covered by the previous test
+      const linkMeta = component.querySelector('a')?.textContent?.match(linkMetaRegex)?.[0] || '';
+      expect(linkMeta).toContain(expected[contextLocale]);
+    });    
+  });
 });

--- a/src/components/LinkToFile/LinkToFile.test.ts
+++ b/src/components/LinkToFile/LinkToFile.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'vitest';
+import { datocmsAssetsOrigin } from '@lib/datocms';
+import { renderToFragment } from '@lib/renderer';
+import LinkToFile, { type Props as LinkToFileProps } from './LinkToFile.astro';
+
+const mockFileLinkProps = ({ basename }: { basename: string }) => {
+  return {
+    record: { 
+      __typename: 'FileRecord',
+      id: '123',
+      title: basename,
+      file: { 
+        basename: basename,
+        filename: `123-${basename}`,
+        format: 'pdf',
+        mimeType: 'application/pdf',
+        size: 123456,
+        url: new URL(`/path/to/123-${basename}`, datocmsAssetsOrigin).toString(),
+      },
+    }
+  } as LinkToFileProps;
+};
+
+describe('LinkToFile', async () => {
+  const pdfProps = mockFileLinkProps({ basename: 'example.pdf' });
+  const pdfLink = await renderToFragment<LinkToFileProps>(LinkToFile, { props: pdfProps });
+  // todo: add another example file docx?
+
+  test('renders as a link to proxied file url', () => {
+    expect(pdfLink.querySelector('a')?.getAttribute('href')).toBe('/files/path/to/123-example.pdf');
+  });
+
+  test('uses the record title as the link text', () => {
+    expect(pdfLink.querySelector('a')?.textContent).toContain(pdfProps.record.title);
+  });
+
+  test('uses the file\'s basename as [download] value', () => {
+    expect(pdfLink.querySelector('a')?.getAttribute('download')).toBe('example.pdf');
+  });
+
+  test('uses the file\'s mimetype as [type] value',  () => {
+    expect(pdfLink.querySelector('a')?.getAttribute('type')).toBe('application/pdf');
+  });
+
+  test('includes file meta between brackets', () => {
+    expect(pdfLink.querySelector('a')?.textContent).toMatch(/\(.+\)/);
+  });
+
+  test('renders the file\'s format capitalised as meta data', () => {
+    // todo: check if format is actually between brackets? extract meta text first?
+    expect(pdfLink.querySelector('a')?.textContent).toContain(pdfProps.record.file.format.toUpperCase());
+  });
+
+  test('renders the filesize as meta data in human readable format', () => {
+    // todo: check if format is actually between brackets? extract meta text first?
+    // todo: different file sizes?
+    expect(pdfLink.querySelector('a')?.textContent).toContain('123 kB');
+  });
+
+  // test hreflang
+  // test locale between brackets if ... (French), (Frans) (mock locale?)
+});

--- a/src/components/LinkToFile/README.md
+++ b/src/components/LinkToFile/README.md
@@ -1,0 +1,18 @@
+# Link to File
+
+**Download link for a file, with accessible meta data (language, format and size).**
+
+## Features
+
+- Triggers a file download forced by the `a[download]` attribute. It uses the file's original name (or the one from the customised file `slug` field) rather than the auto-generated URL from DatoCMS. This feature relies on [file proxy redirects](../../../docs/routing.md#file-redirects), as the [`download` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download) only works on same-domain URLs.
+- Shows language of the file contents (when different from the current page language) for better accessibility. Displayed in brackets as link suffix. Example: `(French)` on an English page.
+- Shows the file format so users understand the link doesn't navigate to another page, but rather downloads a file. This improves accessibility and over user experience. Example `(PDF)`.
+- Shows the file size in human readable. This allows users to avoid unnecessary downloads, which is also eco-responsible (green) best practice. Example: `(2.5 MB)`.
+- Has icon to visually distinguish downloads. Can easily be removed or replaced with another (format specific) icon.
+- Adds locale (`a[hreflang]`) and mime type (`a[type]`) for assistive technology and other applications. Example: `<a href="..." hreflang="fr" type="application/pdf">`.
+
+## Relevant links
+
+- [Orange.com: a11y guidelines for download links](https://a11y-guidelines.orange.com/en/articles/download-links/)
+- [Accessibilly.com: Proposal for a more accessible Download Link
+](https://accessabilly.com/proposal-for-a-more-accessible-download-link/)

--- a/src/components/LinkToRecord/LinkToRecord.astro
+++ b/src/components/LinkToRecord/LinkToRecord.astro
@@ -11,13 +11,13 @@ export type Props = {
 };
 
 const { record, openInNewTab, ...props } = Astro.props;
+
 const locale = getLocale() as SiteLocale;
 const href = getHref({ locale, record });
-const isType = (type: string) => record.__typename === type;
 ---
 
 {
-  (isType('FileRecord'))
-    ? <LinkToFile { record } {...props}><slot>{record.title}</slot></LinkToFile>
+  (record.__typename === 'FileRecord')
+    ? <LinkToFile {record} {...props}><slot>{record.title}</slot></LinkToFile>
     : <Link {href} {openInNewTab} {...props}><slot>{record.title}</slot></Link>
 }

--- a/src/components/LinkToRecord/LinkToRecord.astro
+++ b/src/components/LinkToRecord/LinkToRecord.astro
@@ -3,6 +3,7 @@ import type { SiteLocale } from '@lib/datocms/types';
 import { getLocale } from '@lib/i18n';
 import { getHref, type RecordRoute } from '@lib/routing';
 import Link from '@components/Link/Link.astro';
+import LinkToFile from '@components/LinkToFile/LinkToFile.astro';
 
 export type Props = {
   openInNewTab?: boolean;
@@ -12,6 +13,11 @@ export type Props = {
 const { record, openInNewTab, ...props } = Astro.props;
 const locale = getLocale() as SiteLocale;
 const href = getHref({ locale, record });
+const isType = (type: string) => record.__typename === type;
 ---
 
-<Link {href} {openInNewTab} {...props}><slot>{record.title}</slot></Link>
+{
+  (isType('FileRecord'))
+    ? <LinkToFile { record } {...props}><slot>{record.title}</slot></LinkToFile>
+    : <Link {href} {openInNewTab} {...props}><slot>{record.title}</slot></Link>
+}

--- a/src/lib/datocms/index.ts
+++ b/src/lib/datocms/index.ts
@@ -8,6 +8,8 @@ import { DATOCMS_READONLY_API_TOKEN, HEAD_START_PREVIEW } from 'astro:env/server
 
 const wait = (milliSeconds: number) => new Promise((resolve) => setTimeout(resolve, milliSeconds));
 
+export const datocmsAssetsOrigin = 'https://www.datocms-assets.com/';
+
 type DatocmsRequest = {
   query: DocumentNode;
   variables?: { [key: string]: string };

--- a/src/lib/routing/FileRoute.fragment.graphql
+++ b/src/lib/routing/FileRoute.fragment.graphql
@@ -1,0 +1,13 @@
+fragment FileRoute on FileRecord {
+  id
+  file {
+    basename
+    filename
+    format
+    mimeType
+    size
+    url
+  }
+  locale
+  title
+}

--- a/src/lib/routing/FileRoute.fragment.graphql
+++ b/src/lib/routing/FileRoute.fragment.graphql
@@ -1,4 +1,5 @@
 fragment FileRoute on FileRecord {
+  __typename
   id
   file {
     basename

--- a/src/lib/routing/index.test.ts
+++ b/src/lib/routing/index.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test, vi } from 'vitest';
+import type { FileRouteFragment, HomeRouteFragment, PageRouteFragment, SiteLocale } from '@lib/datocms/types';
+import { datocmsAssetsOrigin } from '@lib/datocms';
+import { getHref, getFileHref, getHomeHref, getPageHref } from './index';
+
+vi.mock('@lib/datocms', () => ({
+  datocmsAssetsOrigin: 'https://www.datocms-assets.com/',
+}));
+
+vi.mock('@lib/i18n', () => ({
+  getLocale: () => 'en',
+}));
+
+const fileRecord: FileRouteFragment = { 
+  __typename: 'FileRecord',
+  id: '123',
+  title: 'example.pdf',
+  file: { 
+    basename: 'example.pdf',
+    filename: 'example.pdf',
+    format: 'pdf',
+    mimeType: 'application/pdf',
+    size: 123456,
+    url: new URL('/path/to/example.pdf', datocmsAssetsOrigin).toString(),
+  },
+};
+
+const homeRecord: HomeRouteFragment = { 
+  __typename: 'HomePageRecord',
+  title: 'Home'
+};
+
+const pageRecord: PageRouteFragment = {
+  __typename: 'PageRecord',
+  id: '123',
+  title: 'Example Page',
+  slug: 'example-page',
+  _allSlugLocales: [{ locale: 'en' as SiteLocale, value: 'example-page' }],
+};
+
+describe('getFileHref', () => {
+  test('returns relative (/files/:filename) href for a given file record', () => {
+    const href = getFileHref(fileRecord);
+    expect(href).toBe('/files/path/to/example.pdf');
+  });
+});
+
+describe('getHomeHref', () => {
+  test('returns the home href for a given locale', () => {
+    expect(getHomeHref({ locale: 'en' })).toBe('/en/');
+    expect(getHomeHref({ locale: 'nl' })).toBe('/nl/');
+  });
+
+  test('returns the home href for current locale if no locale is provided', () => {
+    expect(getHomeHref()).toBe('/en/');
+  });
+
+  test('returns href with trailing slash', () => {
+    expect(getHomeHref()).toMatch(/\/$/);
+  });
+});
+
+describe('getPageHref', () => {
+  const locale = 'en' as SiteLocale;
+  test('returns the page href for a given locale and page record', () => {
+    expect(getPageHref({ locale, record: pageRecord })).toBe('/en/example-page/');
+  });
+
+  test('returns href with trailing slash', () => {
+    expect(getPageHref({ locale, record: pageRecord })).toMatch(/\/$/);
+  });
+
+  const nestedRecord: PageRouteFragment = {
+    __typename: 'PageRecord',
+    id: '123',
+    title: 'Nested Page',
+    slug: 'nested-page',
+    _allSlugLocales: [{ locale, value: 'nested-page' }],
+    parentPage: {
+      __typename: 'PageRecord',
+      id: '456',
+      title: 'Parent Page',
+      slug: 'parent-page',
+      _allSlugLocales: [{ locale, value: 'parent-page' }],
+    },
+  };
+
+  test('returns the full page href for a nested page record', () => {
+    expect(getPageHref({ locale, record: nestedRecord })).toBe('/en/parent-page/nested-page/');
+  });
+});
+
+describe('getHref', () => {
+  const locale = 'en' as SiteLocale;
+
+  test('returns file href for a FileRecord', () => {
+    expect(getHref({ locale, record: fileRecord })).toBe('/files/path/to/example.pdf');
+  });
+
+  test('returns home href for a HomeRecord', () => {
+    expect(getHref({ locale, record: homeRecord })).toBe('/en/');
+  });
+
+  test('returns page href for a PageRecord', () => {
+    expect(getHref({ locale, record: pageRecord })).toBe('/en/example-page/');
+  });
+});

--- a/src/lib/routing/index.ts
+++ b/src/lib/routing/index.ts
@@ -16,6 +16,10 @@ export const getHomeHref = ({ locale = getLocale() } = {}) => {
   return `/${locale}/`;
 };
 
+export const getPageHref = ({ locale, record }: { locale: SiteLocale, record: PageRouteFragment }) => {
+  return `/${locale}/${getPagePath({ page: record, locale })}/`;
+};
+
 /**
  * Determine pathname based on locale and record type
  */
@@ -33,7 +37,7 @@ export const getHref = (
     return homeUrl;
   }
   if (record.__typename === 'PageRecord') {
-    return `/${locale}/${getPagePath({ page: record, locale })}/`;
+    return getPageHref({ locale, record });
   }
   return homeUrl;
 };

--- a/src/lib/routing/index.ts
+++ b/src/lib/routing/index.ts
@@ -1,11 +1,16 @@
-import type { HomeRouteFragment, PageRouteFragment, SiteLocale } from '@lib/datocms/types';
+import type { FileRouteFragment, HomeRouteFragment, PageRouteFragment, SiteLocale } from '@lib/datocms/types';
+import { datocmsAssetsOrigin } from '@lib/datocms';
 import { getLocale } from '@lib/i18n';
-
 import { getPagePath } from './page';
 
 export type RecordRoute =
+  | FileRouteFragment
   | HomeRouteFragment
   | PageRouteFragment;
+
+export const getFileHref = (record: FileRouteFragment) => {
+  return record.file.url.replace(datocmsAssetsOrigin, '/files/');
+};
 
 export const getHomeHref = ({ locale = getLocale() } = {}) => {
   return `/${locale}/`;
@@ -20,6 +25,9 @@ export const getHref = (
   const homeUrl = getHomeHref({ locale });
   if (!record) {
     return homeUrl;
+  }
+  if (record.__typename === 'FileRecord') {
+    return getFileHref(record);
   }
   if (record.__typename === 'HomePageRecord') {
     return homeUrl;

--- a/src/lib/routing/redirects.test.ts
+++ b/src/lib/routing/redirects.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from 'vitest';
-import { defaultRedirectStatus, getRedirectTarget, redirectStatusCode } from '@lib/routing/redirects';
+import { defaultRedirectStatus, getRedirectTarget, redirectStatusCode } from './redirects';
 
 vi.mock('./redirects.json', () => (
   {

--- a/src/pages/[locale]/[...path]/index.astro
+++ b/src/pages/[locale]/[...path]/index.astro
@@ -1,5 +1,6 @@
 ---
 import { datocmsCollection, datocmsRequest } from '@lib/datocms';
+import { getPageHref } from '@lib/routing/';
 import { type PageRouteForPath, getPagePath, getPageSlugFromPath, getParentPages } from '@lib/routing/page';
 import type { PageQuery, SiteLocale } from '@lib/datocms/types';
 import type { PageUrl } from '@lib/seo';
@@ -53,15 +54,12 @@ const { page } = (await datocmsRequest<PageQuery>({ query, variables })) as {
 const breadcrumbs = [...getParentPages(page), page].map((page) =>
   formatBreadcrumb({
     text: page.title,
-    href: `/${locale}/${getPagePath({ page, locale })}/`,
+    href: getPageHref({ locale, record: page }),
   })
 );
 const pageUrls = (page._allSlugLocales || []).map(({ locale }) => ({
   locale: locale as SiteLocale,
-  pathname: `/${locale}/${getPagePath({
-    page,
-    locale: locale as SiteLocale,
-  })}/`,
+  pathname: getPageHref({ locale: locale as SiteLocale, record: page }),
 })) as PageUrl[];
 ---
 

--- a/src/pages/files/[...filename].ts
+++ b/src/pages/files/[...filename].ts
@@ -1,0 +1,21 @@
+import type { APIRoute } from 'astro';
+import { datocmsAssetsOrigin } from '@lib/datocms';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ params }) => {
+  const url = new URL(String(params.filename), datocmsAssetsOrigin).toString(); 
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${url}`);
+    }
+    return response;
+  } catch(error) {
+    console.error('Failed to fetch, redirecting instead', url, error);
+    return new Response('',{
+      status: 307,
+      headers: { 'Location': url },
+    });
+  }
+};


### PR DESCRIPTION
# Changes

- Adds a new `file` model that provides a generic pattern for content editors to add and reference files.
  - Editors can upload an asset and link to the file records in text and other fields.
  - Editors can select the locale of a file for improved accessibility.
- Adds a `LinkToFile` component. See its README for details.
- Adds a `/files/[...filename].ts` route to proxy files, so they can be used as downloads.

In CMS:
![image](https://github.com/user-attachments/assets/a44329aa-b9a7-4eeb-a636-66dabd1be1c4)

In Page (EN and NL):
![image](https://github.com/user-attachments/assets/5bc64db1-0712-4d3e-8e93-4790f176700e)
![image](https://github.com/user-attachments/assets/bf4fdee6-3ca5-47b3-8073-98f0b854cc06)


# Associated issue

Resolves #148
Closes #147 (outdated earlier attempt based on older routing)

# How to test

1. Navigate to the [Files demo page (en)](https://feat-file-downloads.head-start.pages.dev/en/demos/file-demo/)
2. Review the links and verify that they work.
3. Switch to nl locale.
4. Review the links (see they now also display the language of the file) and verify that they work.
5. Navigate to the page in the CMS
6. Test and verify how adding a file and a link to it works

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
