### PR TITLE
fix: conditionally set default locale on server & client

### DIFF
--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -10,7 +10,7 @@ export const cookieName = 'HEAD_START_LOCALE';
 const i18n = rosetta(messages);
 
 if (typeof document !== 'undefined') {
-  i18n.locale(document.documentElement.lang as SiteLocale);
+  setLocale(document.documentElement.lang as SiteLocale);
 } else {
   i18n.locale(defaultLocale);
 }

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -8,7 +8,12 @@ export const defaultLocale = locales[0];
 export const cookieName = 'HEAD_START_LOCALE';
 
 const i18n = rosetta(messages);
-i18n.locale(defaultLocale);
+
+if (typeof document !== 'undefined') {
+  i18n.locale(document.documentElement.lang as SiteLocale);
+} else {
+  i18n.locale(defaultLocale);
+}
 
 export type T = typeof i18n.t & ((key: TranslationKey) => string);
 // we use the 'any' type since this is used in the rosetta source-code


### PR DESCRIPTION
# Changes

- When `src/lib/i18n/index.ts` is run in the client, extract the current locale from the `lang` attribute. Otherwise, it just resets to the default locale. This fixes `t()` and `getLocale()` in combination with `client:load` components.

# How to test

- Use either functions inside a component with `client:load`. Translations should now work as expected.

# Checklist

- [X] I have performed a self-review of my own code
- [X] I have made sure that my PR is easy to review (not too big, includes comments)
- [X] I have made updated relevant documentation files (in project README, docs/, etc)
- [X] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [X] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
