### PR TITLE
perf: cache static assets (generated by Astro)

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -9,3 +9,7 @@
   X-Content-Type-Options: nosniff
   X-Frame-Options: SAMEORIGIN
   X-XSS-Protection: 1; mode=block
+
+# Static assets are hashed and can therefore be cached forever
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
# Changes

Adds cache header so all static assets generated by Astro are cached forever, making repeat visits faster.

# Associated issue

Resolves #197

# How to test

Verify the repeat view is faster on this deploy preview. 

Tests below are performed using [WebPageTest](https://www.webpagetest.org/) with "include repeat visit" checked.

### Before on https://head-start.pages.dev/en/ 

[First visit](https://www.webpagetest.org/result/241108_AiDcN1_9KY/1/details/#waterfall_view_step1):

![image](https://github.com/user-attachments/assets/427f8609-9afb-419c-b024-91131e1113ca)

[Repeat visit](https://www.webpagetest.org/result/241108_AiDcN1_9KY/1/details/cached/):

![image](https://github.com/user-attachments/assets/192470ee-9400-4e2c-b84b-bb555dfee0af)

### After on https://perf-197-cache-static-assets.head-start.pages.dev/en/

[First visit (unchanged)](https://www.webpagetest.org/result/241108_BiDcSD_9Q8/1/details/#waterfall_view_step1)

![image](https://github.com/user-attachments/assets/eaf22cf0-723d-4a82-b46f-6a9db5fdae0f)

[Repeat visit (faster)](https://www.webpagetest.org/result/241108_BiDcSD_9Q8/1/details/cached/)

![image](https://github.com/user-attachments/assets/8e669c66-e028-41de-9c2d-6ed348bff13f)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- ~~I have made updated relevant documentation files (in project README, docs/, etc)~~
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
