### PR TITLE
perf: preconnect origins for faster pages

### DIFF
--- a/src/components/PerfHead/PerfHead.astro
+++ b/src/components/PerfHead/PerfHead.astro
@@ -1,0 +1,7 @@
+---
+import { datocmsAssetsOrigin, datocmsGraphqlOrigin } from '@lib/datocms';
+
+const preConnectOrigins = [datocmsAssetsOrigin, datocmsGraphqlOrigin];
+---
+
+{preConnectOrigins.map((origin) => <link rel="preconnect" href={origin} />)}

--- a/src/components/PerfHead/README.md
+++ b/src/components/PerfHead/README.md
@@ -1,0 +1,7 @@
+# Perf Head
+
+**Loading instructions for resources on criticial rendering path to improve page loading performance.**
+
+## Relevant links
+
+- [web.dev: Establish network connections early to improve perceived page speed](https://web.dev/articles/preconnect-and-dns-prefetch)

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -1,5 +1,10 @@
 ---
-import type { DefaultLayoutQuery, Site, SiteLocale, Tag } from '@lib/datocms/types';
+import type {
+  DefaultLayoutQuery,
+  Site,
+  SiteLocale,
+  Tag,
+} from '@lib/datocms/types';
 import { datocmsRequest } from '@lib/datocms';
 import { defaultLocale, t } from '@lib/i18n';
 import { getHomeHref } from '@lib/routing';
@@ -11,6 +16,7 @@ import Breadcrumbs from '@components/Breadcrumbs/Breadcrumbs.astro';
 import type { Breadcrumb } from '@components/Breadcrumbs';
 import IconSprite from '@components/Icon/IconSprite.astro';
 import LocaleSelector from '@components/LocaleSelector/LocaleSelector.astro';
+import PerfHead from '@components/PerfHead/PerfHead.astro';
 import PreviewModeProvider from '@components/PreviewMode/PreviewModeProvider.astro';
 import StructuredData from '@components/StructuredData/StructuredData.astro';
 import SeoHead from '@components/SeoHead.astro';
@@ -24,41 +30,51 @@ interface Props {
 }
 
 const { locale = defaultLocale } = Astro.params as { locale?: SiteLocale };
-const data = await datocmsRequest<DefaultLayoutQuery>({ query, variables: { locale } }) as { site: Site };
+const data = (await datocmsRequest<DefaultLayoutQuery>({
+  query,
+  variables: { locale },
+})) as { site: Site };
 const { breadcrumbs = [], pageUrls, seoMetaTags } = Astro.props;
 const mainContentId = 'content';
 ---
 
-<!DOCTYPE html>
-<html lang={ locale }>
+<!doctype html>
+<html lang={locale}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
-    <StructuredData />
+    <PerfHead />
     <SeoHead
-      pageUrls={ pageUrls }
+      pageUrls={pageUrls}
       tags={[...data.site.faviconMetaTags, ...seoMetaTags]}
     />
+    <StructuredData />
   </head>
   <body>
     <PreviewModeProvider>
-      <SkipLink targetId={ mainContentId } />
-      <header { ...datocmsNoIndex }>
-        { /* accessible home link, inspired by https://www.gov.uk/; with Microformats rel */ }
-        <a rel="home" href={ getHomeHref() } aria-label={ t('go_to_home_page', { siteName }) }>[Logo]</a>
+      <SkipLink targetId={mainContentId} />
+      <header {...datocmsNoIndex}>
+        {
+          /* accessible home link, inspired by https://www.gov.uk/; with Microformats rel */
+        }
+        <a
+          rel="home"
+          href={getHomeHref()}
+          aria-label={t('go_to_home_page', { siteName })}>[Logo]</a
+        >
         <div>
-          <LocaleSelector pageUrls={ pageUrls } />
-          <a rel="search" href={ getSearchPathname(locale) }>{ t('search') }</a>
+          <LocaleSelector pageUrls={pageUrls} />
+          <a rel="search" href={getSearchPathname(locale)}>{t('search')}</a>
         </div>
       </header>
-      { (breadcrumbs.length > 0) && (
-        <Breadcrumbs items={breadcrumbs} />
-      ) }
-      { /* main element requires tabindex to be focusable, see SkipLink/README.md */ }
-      <main id={ mainContentId } tabindex="-1">
+      {breadcrumbs.length > 0 && <Breadcrumbs items={breadcrumbs} />}
+      {
+        /* main element requires tabindex to be focusable, see SkipLink/README.md */
+      }
+      <main id={mainContentId} tabindex="-1">
         <slot />
       </main>
-      <footer { ...datocmsNoIndex }>
+      <footer {...datocmsNoIndex}>
         <p>Footer</p>
       </footer>
     </PreviewModeProvider>
@@ -68,10 +84,13 @@ const mainContentId = 'content';
 
 <style is:global>
   /* very basic reset */
-  *, *::before, *::after {
+  *,
+  *::before,
+  *::after {
     box-sizing: border-box;
   }
-  html, body {
+  html,
+  body {
     margin: 0;
     padding: 0;
     font-family: sans-serif;
@@ -82,7 +101,8 @@ const mainContentId = 'content';
 </style>
 <style>
   /* Sticky footer. @see https://css-tricks.com/a-clever-sticky-footer-technique/ */
-  html, body {
+  html,
+  body {
     height: 100%;
   }
   footer {

--- a/src/lib/datocms/index.ts
+++ b/src/lib/datocms/index.ts
@@ -8,6 +8,9 @@ import { DATOCMS_READONLY_API_TOKEN, HEAD_START_PREVIEW } from 'astro:env/server
 
 const wait = (milliSeconds: number) => new Promise((resolve) => setTimeout(resolve, milliSeconds));
 
+export const datocmsAssetsOrigin = 'https://www.datocms-assets.com/';
+export const datocmsGraphqlOrigin = 'https://graphql.datocms.com/';
+
 type DatocmsRequest = {
   query: DocumentNode;
   variables?: { [key: string]: string };
@@ -29,7 +32,7 @@ export const datocmsRequest = async <T>({ query, variables = {}, retryCount = 1 
     headers.append('X-Include-Drafts', 'true');
   }
 
-  const response = await fetch('https://graphql.datocms.com/', {
+  const response = await fetch(datocmsGraphqlOrigin, {
     method: 'post',
     headers,
     body: JSON.stringify({ query: print(query), variables }),


### PR DESCRIPTION
# Changes

Adds resource hints to preconnect DatoCMS assets and GraphQL (content delivery) API origins, so when the browser later does requests to those origins they are resolved faster.

I introduced a `<PerfHead>` component to bundle all performance related meta/link tags, similar to `<SeoHead>`.

# Associated issue

Resolves #200

# How to test

Verify the DatoCMS assets origin is `preconnect`ed earlier (1.3s before, 0.6 after) and images from that origin are loaded faster (1.8s before, 1.2s after) on this deploy preview. 

Tests below are performed using [WebPageTest](https://www.webpagetest.org/) with "include repeat visit" checked.

## Before on https://head-start.pages.dev/en/ 

[test results](https://www.webpagetest.org/result/241107_AiDc9D_406/1/details/#waterfall_view_step1):

![image](https://github.com/user-attachments/assets/ab40a908-c83b-4300-8048-a8053c6880cf)

## After on 

[test results](https://www.webpagetest.org/result/241109_BiDcJF_4RF/1/details/#waterfall_view_step1):

![image](https://github.com/user-attachments/assets/aa240ed4-6790-4289-a6de-7cc606001cd9)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
