### PR TITLE
feature: proxy files with custom slugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ src/lib/datocms/types.ts
 src/lib/i18n/messages.json
 src/lib/i18n/types.ts
 src/lib/site.json
+src/lib/routing/file-proxy-map.json
 src/lib/routing/redirects.json

--- a/config/datocms/migrations/1734959319_customFilePaths.ts
+++ b/config/datocms/migrations/1734959319_customFilePaths.ts
@@ -1,0 +1,50 @@
+import type { Client } from '@datocms/cli/lib/cma-client-node';
+
+export default async function (client: Client) {
+  console.log('Creating new fields/fieldsets');
+
+  console.log(
+    'Create Single-line string field "Path" (`path`) in model "\uD83D\uDCE6 File" (`file`)'
+  );
+  await client.fields.create('GjWw8t-hTFaYYWyc53FeIg', {
+    id: 'cnnDYybJTAGvHxiYq2MJ8g',
+    label: 'Path',
+    field_type: 'string',
+    api_key: 'path',
+    hint: 'Optional custom path, like <code>/my-files/example.pdf</code>. This may be useful if you need files to be available under a specific URL.',
+    validators: {
+      format: {
+        custom_pattern: '^/.*',
+        description: 'Field must start with a forward slash: /',
+      },
+    },
+    appearance: {
+      addons: [],
+      editor: 'single_line',
+      parameters: { heading: false, placeholder: null },
+    },
+    default_value: '',
+  });
+
+  console.log('Update existing fields/fieldsets');
+
+  console.log(
+    'Update Single-line string field "Path" (`path`) in model "\uD83D\uDCE6 File" (`file`)'
+  );
+  await client.fields.update('cnnDYybJTAGvHxiYq2MJ8g', { position: 3 });
+
+  console.log(
+    'Update Single-line string field "Title" (`title`) in model "\uD83D\uDCE6 File" (`file`)'
+  );
+  await client.fields.update('YIftd04cTlyz0aEvqsfWXA', {
+    appearance: {
+      addons: [],
+      editor: 'EiyZ3d0SSDCPCNbsKBIwWQ',
+      parameters: {
+        defaultFunction:
+          'if (path) {\n return path.split(\'/\').pop()\n}\nconst upload = await getUpload(file.upload_id)\nreturn `${upload.filename}`',
+      },
+      field_extension: 'computedFields',
+    },
+  });
+}

--- a/datocms-environment.ts
+++ b/datocms-environment.ts
@@ -3,5 +3,5 @@
  * @see docs/getting-started.md on how to use this file
  * @see docs/decision-log/2023-10-24-datocms-env-file.md on why file is preferred over env vars
  */
-export const datocmsEnvironment = 'email-phone-links';
+export const datocmsEnvironment = 'custom-file-paths';
 export const datocmsBuildTriggerId = '30535';

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "prep:clean-astro-env": "rm -rf node_modules/.astro",
     "prep:cloudflare-env": "touch .dev.vars",
     "prep:datocms-types": "graphql-codegen --config .graphqlrc.ts",
+    "prep:download-file-proxy-map": "jiti scripts/download-file-proxy-map.ts",
     "prep:download-redirects": "jiti scripts/download-redirects.ts",
     "prep:download-site-data": "jiti scripts/download-site-data.ts",
     "prep:download-translations": "jiti scripts/download-translations.ts",

--- a/scripts/download-file-proxy-map.ts
+++ b/scripts/download-file-proxy-map.ts
@@ -1,0 +1,46 @@
+import { writeFile } from 'node:fs/promises';
+import { buildClient } from '@datocms/cma-client-node';
+import dotenv from 'dotenv-safe';
+import { datocmsEnvironment } from '../datocms-environment';
+
+dotenv.config({
+  allowEmptyValues: Boolean(process.env.CI),
+});
+
+type FileRecord = {
+  path?: string;
+  file: {
+    upload_id: string;
+  }
+}
+type FilePathMap = {
+  [key: string]: string;
+};
+
+async function getFileProxyMap() {
+  // use client instead of http api for pagination support
+  const client = buildClient({
+    apiToken: process.env.DATOCMS_READONLY_API_TOKEN!,
+    environment: datocmsEnvironment,
+  });
+
+  const filePathMap: FilePathMap = {};
+    
+  for await (const item of client.items.listPagedIterator({ filter: { type: 'file' } }) as unknown as FileRecord[]) {
+    if (item.path) {
+      const asset = await client.uploads.find(item.file.upload_id);
+      if (asset) {
+        filePathMap[item.path] = asset.url;
+      }
+    }
+  }
+  return filePathMap;
+}
+
+async function downloadFileProxyMap() {
+  const files = await getFileProxyMap();
+  await writeFile('./src/lib/routing/file-proxy-map.json', JSON.stringify(files, null, 2));
+}
+
+downloadFileProxyMap()
+  .then(() => console.log('File paths downloaded'));

--- a/src/lib/routing/FileRoute.fragment.graphql
+++ b/src/lib/routing/FileRoute.fragment.graphql
@@ -10,5 +10,6 @@ fragment FileRoute on FileRecord {
     url
   }
   locale
+  path
   title
 }

--- a/src/lib/routing/file.ts
+++ b/src/lib/routing/file.ts
@@ -1,0 +1,21 @@
+import type { FileRouteFragment } from '@lib/datocms/types';
+import { datocmsAssetsOrigin } from '@lib/datocms';
+import fileProxyMapUntyped from './file-proxy-map.json';
+
+export const getFileHref = (record: FileRouteFragment) => {
+  if (record.path) {
+    return record.path;
+  }
+
+  return record.file.url.replace(datocmsAssetsOrigin, '/files/');
+};
+
+type FileProxyMap = {
+  [key: string]: string;
+};
+
+const fileProxyMap: FileProxyMap = fileProxyMapUntyped;
+
+export const getFileUrlByPath = (path: string) => {
+  return fileProxyMap[path];
+};

--- a/src/lib/routing/index.ts
+++ b/src/lib/routing/index.ts
@@ -1,16 +1,14 @@
 import type { FileRouteFragment, HomeRouteFragment, PageRouteFragment, SiteLocale } from '@lib/datocms/types';
-import { datocmsAssetsOrigin } from '@lib/datocms';
 import { getLocale } from '@lib/i18n';
 import { getPagePath } from './page';
+import { getFileHref } from './file';
 
 export type RecordRoute =
   | FileRouteFragment
   | HomeRouteFragment
   | PageRouteFragment;
 
-export const getFileHref = (record: FileRouteFragment) => {
-  return record.file.url.replace(datocmsAssetsOrigin, '/files/');
-};
+export { getFileHref } from './file';
 
 export const getHomeHref = ({ locale = getLocale() } = {}) => {
   return `/${locale}/`;

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -3,11 +3,13 @@ import {  sequence } from 'astro:middleware';
 import { datocms } from './datocms';
 import { i18n } from './i18n';
 import { preview } from './preview';
+import { proxyFiles } from './proxy-files';
 import { redirects } from './redirects';
 
 export const onRequest = sequence(
   datocms,
   i18n,
   preview,
+  proxyFiles,
   redirects
 );

--- a/src/middleware/proxy-files.ts
+++ b/src/middleware/proxy-files.ts
@@ -1,0 +1,37 @@
+import { defineMiddleware } from 'astro/middleware';
+import { getFileUrlByPath } from '@lib/routing/file';
+
+/**
+ * Proxy files middleware:
+ * If there is no matching route (404) and there is a file with a matching custom slug,
+ * proxy the file from DatoCMS assets.
+ */
+export const proxyFiles = defineMiddleware(async ({ request }, next) => {
+  const originalResponse = await next();
+
+  // only process 404 responses
+  if (originalResponse.status !== 404) {
+    return originalResponse;
+  }
+
+  const { pathname } = new URL(request.url);
+  const fileUrl = getFileUrlByPath(pathname);
+  if (!fileUrl) {
+    return originalResponse;
+  }
+
+  const fileResponse = await fetch(fileUrl);
+  if (!fileResponse.ok) {
+    return originalResponse;
+  }
+
+  // Astro forces the original 404 status unless we use `X-Astro-Rewrite: true`
+  // @see https://github.com/withastro/roadmap/discussions/665#discussioncomment-6831528
+  return new Response(fileResponse.body, {
+    ...fileResponse,
+    headers: {
+      ...fileResponse.headers,
+      'X-Astro-Rewrite': 'true',
+    },
+  });
+});


### PR DESCRIPTION
# Changes

Makes files available under custom URLs by

- Adding an optional custom `slug` field to the File model.
- Adding middleware to proxy serve files under their custom slugs. For example `/my-files/example.pdf` serves `https://www.datocms-assets.com/145765/1730925112-dummy.pdf`.

# Associated issue

Resolves #155

# How to test

1. Open preview link
2. Navigate to the File Demo
3. Try the part under "File with a custom slug"
4. Verify that the file is proxied (available) under a custom slug
5. Play around with custom file slugs in the CMS
6. Verify your changes work (will need to run branch locally as deploy preview doesn't update)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
