### PR TITLE
feat(Link): Allow `<a>` attrs as props in Typescript

### DIFF
--- a/src/blocks/TextBlock/nodes/ItemLink.astro
+++ b/src/blocks/TextBlock/nodes/ItemLink.astro
@@ -1,6 +1,7 @@
 ---
-import LinkToRecord from '@components/LinkToRecord/LinkToRecord.astro';
+import type { HTMLAttributes } from 'astro/types';
 import type { RecordRoute } from '@lib/routing';
+import LinkToRecord from '@components/LinkToRecord/LinkToRecord.astro';
 
 type Node = {
   meta?: {
@@ -9,7 +10,7 @@ type Node = {
   }[];
 };
 
-export type Props = {
+export type Props = HTMLAttributes<'a'> & {
   node?: Node;
   link: RecordRoute;
 };

--- a/src/components/Link/Link.astro
+++ b/src/components/Link/Link.astro
@@ -1,5 +1,7 @@
 ---
-export interface Props {
+import type { HTMLAttributes } from 'astro/types';
+
+export type Props = HTMLAttributes<'a'> & {
   href: string;
   openInNewTab?: boolean;
 }

--- a/src/components/LinkToFile/LinkToFile.astro
+++ b/src/components/LinkToFile/LinkToFile.astro
@@ -1,13 +1,15 @@
 ---
+import type { HTMLAttributes } from 'astro/types';
 import type { FileRouteFragment } from '@lib/datocms/types';
 import prettyBytes from 'pretty-bytes';
 import { getLocale } from '@lib/i18n';
 import { getFileHref } from '@lib/routing/';
 import Icon from '@components/Icon';
 
-export type Props = {
+export type Props = HTMLAttributes<'a'> & {
   record: FileRouteFragment;
 };
+
 const { record, ...props } = Astro.props;
 const { file, locale: fileLocale, title } = record;
 const pageLocale = getLocale();

--- a/src/components/LinkToRecord/LinkToRecord.astro
+++ b/src/components/LinkToRecord/LinkToRecord.astro
@@ -1,11 +1,12 @@
 ---
+import type { HTMLAttributes } from 'astro/types';
 import type { SiteLocale } from '@lib/datocms/types';
 import { getLocale } from '@lib/i18n';
 import { getHref, type RecordRoute } from '@lib/routing';
 import Link from '@components/Link/Link.astro';
 import LinkToFile from '@components/LinkToFile/LinkToFile.astro';
 
-export type Props = {
+export type Props = Omit<HTMLAttributes<'a'>,'href'> & {
   openInNewTab?: boolean;
   record: RecordRoute;
 };


### PR DESCRIPTION
# Changes

- Adds Astro builtin HTML tag definition to any component that spreads rest props.
 
# How to test

1. Try adding any prop not explicitly defined in the `Astro.props` (for instance `class`) to a `<Link>` in another component. 
2. See that it does not produce an Typescript error when linting.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] ~I have made updated relevant documentation files (in project README, docs/, etc)~
- [ ] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [ ] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
