### PR TITLE
feat(Icon): expose support icon names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ node_modules/
 
 # generated files
 src/assets/icon-sprite.svg
-src/assets/icon-sprite.d.ts
+src/assets/icon-sprite.ts
 src/lib/datocms/types.ts
 src/lib/i18n/messages.json
 src/lib/i18n/types.ts

--- a/scripts/icon-types.ts
+++ b/scripts/icon-types.ts
@@ -7,10 +7,11 @@ async function writeIconNameTypes() {
     .filter(file => file.endsWith('.svg'))
     .map(file => path.basename(file, '.svg'));
 
-  await fs.writeFile('./src/assets/icon-sprite.d.ts', 
-    `export type IconName = ${iconNames.map(name => `'${name}'`).join(' | ')};`
+  await fs.writeFile('./src/assets/icon-sprite.ts', 
+    `export const iconNames = [${iconNames.map(name => `'${name}'`)}] as const;\n` +
+    'export type IconName = typeof iconNames[number];'
   );
 }
 
 writeIconNameTypes()
-  .then(() => console.log('Icon names written to src/assets/icon-sprite.d.ts'));
+  .then(() => console.log('Icon names written to src/assets/icon-sprite.ts'));

--- a/src/components/Icon/Icon.astro
+++ b/src/components/Icon/Icon.astro
@@ -1,5 +1,6 @@
 ---
 import type { IconName } from '@assets/icon-sprite';
+export { iconNames } from '@assets/icon-sprite';
 
 interface Props {
   name: IconName;

--- a/src/components/Icon/index.ts
+++ b/src/components/Icon/index.ts
@@ -1,2 +1,2 @@
 // Icon component is often used, this makes it easier to import as `path/to/components/Icon`.
-export { default } from './Icon.astro';
+export { default, iconNames } from './Icon.astro';


### PR DESCRIPTION
# Changes

- Writes out supported icons to .ts instead of .d.ts
- Writes a list `as const` so Typescript takes the literal value as the type
- Maps that type to the original IconNames type
- Lets Icon.astro expose the list of supported icons

# How to test

1. Run the project and try to import the iconNames from Icon.astro

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [ ] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
