### PR TITLE
feature: preview links in CMS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 DATOCMS_READONLY_API_TOKEN="<Read-only API token>"
 DATOCMS_API_TOKEN="<Full-access API token>"
+DATOCMS_PREVIEW_API_TOKEN="<Custom API token for preview>"
 HEAD_START_PREVIEW_SECRET=""

--- a/config/datocms/migrations/1734806654_previewLinks.ts
+++ b/config/datocms/migrations/1734806654_previewLinks.ts
@@ -1,0 +1,64 @@
+import { Client } from '@datocms/cli/lib/cma-client-node';
+
+export default async function (client: Client) {
+  console.log('Manage upload filters');
+
+  console.log('Install plugin "Model Deployment Links"');
+  await client.plugins.create({
+    id: 'MKba9NT5QBKZaeI4HcERwA',
+    package_name: 'datocms-plugin-model-deployment-links',
+  });
+  await client.plugins.update('MKba9NT5QBKZaeI4HcERwA', {
+    parameters: { datoApiToken: process.env.DATOCMS_PREVIEW_API_TOKEN },
+  });
+
+  console.log('Creating new fields/fieldsets');
+
+  console.log(
+    'Create JSON field "Preview" (`preview`) in model "\uD83D\uDCD1 Page" (`page`)'
+  );
+  await client.fields.create('LjXdkuCdQxCFT4hv8_ayew', {
+    id: 'XF2LuFVWSrmu7Lle8xlhTg',
+    label: 'Preview',
+    field_type: 'json',
+    api_key: 'preview',
+    localized: true,
+    appearance: {
+      addons: [],
+      editor: 'MKba9NT5QBKZaeI4HcERwA',
+      parameters: { urlPattern: '/{ locale }/{ slug }/' },
+    },
+  });
+
+  console.log(
+    'Create JSON field "Preview" (`preview`) in model "\uD83C\uDFE0 Home" (`home_page`)'
+  );
+  await client.fields.create('X_tZn3TxQY28ltSyjZUGHQ', {
+    id: 'YPXZOMoWRdKTHLUkN9ytfw',
+    label: 'Preview',
+    field_type: 'json',
+    api_key: 'preview',
+    localized: true,
+    appearance: {
+      addons: [],
+      editor: 'MKba9NT5QBKZaeI4HcERwA',
+      parameters: { urlPattern: '/{ locale }/' },
+    },
+  });
+
+  console.log(
+    'Create JSON field "Preview" (`preview`) in model "\uD83E\uDD37 Not found" (`not_found_page`)'
+  );
+  await client.fields.create('d_AvMVoMSqmNbMqx-NdqIw', {
+    id: 'O_DCfpaDSzq1MX4DaRlMpQ',
+    label: 'Preview',
+    field_type: 'json',
+    api_key: 'preview',
+    localized: true,
+    appearance: {
+      addons: [],
+      editor: 'MKba9NT5QBKZaeI4HcERwA',
+      parameters: { urlPattern: '/{ locale }/404' },
+    },
+  });
+}

--- a/datocms-environment.ts
+++ b/datocms-environment.ts
@@ -3,5 +3,5 @@
  * @see docs/getting-started.md on how to use this file
  * @see docs/decision-log/2023-10-24-datocms-env-file.md on why file is preferred over env vars
  */
-export const datocmsEnvironment = 'action-block';
+export const datocmsEnvironment = 'preview-links';
 export const datocmsBuildTriggerId = '30535';

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,9 +1,6 @@
 ---
 import type { SiteLocale } from '@lib/i18n/types';
-import type {
-  NotFoundPageQuery,
-  NotFoundPageRecord,
-} from '@lib/datocms/types';
+import type { NotFoundPageQuery, NotFoundPageRecord } from '@lib/datocms/types';
 import { datocmsRequest } from '@lib/datocms';
 import { noIndexTag, titleTag } from '@lib/seo';
 import Layout from '@layouts/Default.astro';
@@ -15,7 +12,9 @@ export const prerender = false;
 
 Astro.response.status = 404;
 
-const { locale } = Astro.params as { locale: SiteLocale };
+const localeFromPath = Astro.params.locale as SiteLocale;
+const localeFromQuery = Astro.url.searchParams.get('locale') as SiteLocale;
+const locale = localeFromQuery || localeFromPath;
 const { page } = (await datocmsRequest<NotFoundPageQuery>({
   query,
   variables: { locale },
@@ -23,6 +22,6 @@ const { page } = (await datocmsRequest<NotFoundPageQuery>({
 ---
 
 <Layout pageUrls={[]} seoMetaTags={[noIndexTag, titleTag(page.title)]}>
-  <h1>{page.title} {Astro.params.locale}</h1>
+  <h1>{page.title}</h1>
   <Blocks blocks={page.bodyBlocks as AnyBlock[]} />
 </Layout>

--- a/src/pages/[locale]/[...path]/index.astro
+++ b/src/pages/[locale]/[...path]/index.astro
@@ -53,19 +53,30 @@ type Params = {
 
 const { locale, path } = Astro.params as Params;
 const variables = { locale, slug: getPageSlugFromPath(path) };
-const { page } = (await datocmsRequest<PageQuery>({ query, variables })) as {
-  page: NonNullable<PageQuery['page']>; // Only NonNullable when statically generated. Handle as a 404 when this is a server route!
-};
-const breadcrumbs = [...getParentPages(page), page].map((page) =>
+const { page } = await datocmsRequest<PageQuery>({ query, variables });
+
+if (!page) {
+  return Astro.rewrite(`/404/?locale=${locale}`);
+}
+
+const canonicalUrl = getPageHref({ locale, record: page });
+if (Astro.url.pathname !== canonicalUrl) {
+  return Astro.redirect(canonicalUrl);
+}
+
+const breadcrumbs = [...getParentPages(page), page].map((record) =>
   formatBreadcrumb({
-    text: page.title,
-    href: getPageHref({ locale, record: page }),
+    text: record.title,
+    href: getPageHref({ locale, record }),
   })
 );
-const pageUrls = (page._allSlugLocales || []).map(({ locale }) => ({
-  locale: locale as SiteLocale,
-  pathname: getPageHref({ locale: locale as SiteLocale, record: page }),
-})) as PageUrl[];
+
+const pageLocales = (page._allSlugLocales?.map(({ locale }) => locale) ??
+  []) as SiteLocale[];
+const pageUrls = pageLocales.map((locale) => ({
+  locale,
+  pathname: getPageHref({ locale, record: page }),
+})) satisfies PageUrl[];
 ---
 
 <Layout

--- a/src/pages/api/reroute/_page.query.graphql
+++ b/src/pages/api/reroute/_page.query.graphql
@@ -1,0 +1,7 @@
+#import '@lib/routing/PageRoute.fragment.graphql'
+
+query ReroutePage($locale: SiteLocale!, $slug: String!) {
+  page(locale: $locale, filter: { slug: { eq: $slug } }) {
+    ...PageRoute
+  }
+}

--- a/src/pages/api/reroute/page.ts
+++ b/src/pages/api/reroute/page.ts
@@ -1,0 +1,38 @@
+import type { APIRoute } from 'astro';
+import { datocmsRequest } from '@lib/datocms';
+import type { ReroutePageQuery, SiteLocale } from '@lib/datocms/types';
+import { getPageHref } from '@lib/routing';
+import query from './_page.query.graphql';
+
+export const prerender = false;
+
+const jsonResponse = (data: object, status: number = 200) => {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+};
+
+export const GET: APIRoute = async ({ request }) => {
+  const locale = new URL(request.url).searchParams.get('locale') as SiteLocale;
+  if (!locale) {
+    return jsonResponse({ error: 'Missing \'locale\' parameter' }, 400);
+  }
+
+  const slug = new URL(request.url).searchParams.get('slug');
+  if (!slug) {
+    return jsonResponse({ error: 'Missing \'slug\' parameter' }, 400);
+  }
+
+  const { page } = (await datocmsRequest<ReroutePageQuery>({ query, variables: { slug, locale } }));
+  if (!page) {
+    return jsonResponse({ error: 'Page not found' }, 404);
+  }
+
+  return new Response('',{
+    status: 307,
+    headers: { 'Location': getPageHref({ locale, record: page }) },
+  });
+};


### PR DESCRIPTION
# To do

- Get preview secret to be used automatically. If click on the preview links in the sidebar you still need to enter the secret manually (I don't get why). While if you copy the link and paste it in a new browser tab it works as expected.

# Changes

This change contains 2 solutions:

- an `/api/reroute/page` endpoint to find and redirect to the correct page url
- a check in `pages/[locale]/[...path]/index.astro` that redirects to the canonical url if it doesn't match the current url

To do: agree on one, remove the other.

# Associated issue

Part of #10 

# How to test

1. Open the CMS and go to the `preview-links` environment (note: it's moved from personal to De Voorhoede organisation account, so we could add more sandbox environments)
2. Open the sidebar in the home / page / not found page model
3. Try the preview links
4. Verify that they all work as expected

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [ ] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
