### PR TITLE
feature: Service worker (custom Astro integration)

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -5,6 +5,7 @@ import sitemap from '@astrojs/sitemap';
 import type { PluginOption } from 'vite';
 import { isPreview } from './config/preview';
 import pkg from './package.json';
+import serviceWorker from './scripts/service-worker-integration.ts';
 
 const productionUrl = `https://${ pkg.name }.pages.dev`; // overwrite if you have a custom domain
 const localhostPort = 4323; // 4323 is "head" in T9
@@ -50,7 +51,10 @@ export default defineConfig({
     // @see https://docs.astro.build/en/guides/images/#configure-no-op-passthrough-service
     service: passthroughImageService()
   },
-  integrations: [sitemap()],
+  integrations: [
+    sitemap(),
+    serviceWorker()
+  ],
   output: isPreview ? 'server' : 'static',
   server: { port: localhostPort },
   site: siteUrl,

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -5,7 +5,7 @@ import sitemap from '@astrojs/sitemap';
 import type { PluginOption } from 'vite';
 import { isPreview } from './config/preview';
 import pkg from './package.json';
-import serviceWorker from './scripts/service-worker-integration.ts';
+import serviceWorker from './config/astro/service-worker-integration.ts';
 
 const productionUrl = `https://${ pkg.name }.pages.dev`; // overwrite if you have a custom domain
 const localhostPort = 4323; // 4323 is "head" in T9

--- a/config/astro/service-worker-integration.ts
+++ b/config/astro/service-worker-integration.ts
@@ -7,6 +7,16 @@ const filenamePath = (filename: string) => fileURLToPath(new URL(join('../../', 
 const srcFilename = filenamePath('src/assets/service-worker.ts');
 const outFilename = filenamePath('dist/service-worker.js');
 
+const buildConfig = {
+  entryPoints: [srcFilename],
+  outfile: outFilename,
+  target: ['es2020'],
+  bundle: true,
+  minify: true,
+  allowOverwrite: true,
+  sourcemap: true,
+};
+
 export default function serviceWorkerIntegration(): AstroIntegration {
   return {
     name: 'service-worker',
@@ -28,13 +38,8 @@ export default function serviceWorkerIntegration(): AstroIntegration {
       'astro:build:done': async () => {
         try {
           await esbuild.build({
-            entryPoints: [srcFilename],
-            outfile: outFilename,
-            target: ['es2020'],
-            bundle: true,
-            minify: true,
-            allowOverwrite: true,
-            sourcemap: true,
+            ...buildConfig,
+            write: true,
           });
         } catch (e) {
           console.error('Failed to build service worker');
@@ -48,13 +53,9 @@ export default function serviceWorkerIntegration(): AstroIntegration {
 
 export const GET: APIRoute = async () => {
   const output =  await esbuild.build({
-    entryPoints: [srcFilename],
-    outdir: outFilename,
-    target: ['es2020'],
-    bundle: true,
-    minify: false,
+    ...buildConfig,
     write: false,
-    allowOverwrite: true,
+    minify: false,
     sourcemap: false,
   });
 

--- a/config/astro/service-worker-integration.ts
+++ b/config/astro/service-worker-integration.ts
@@ -2,8 +2,8 @@ import type { APIRoute, AstroIntegration } from 'astro';
 import { fileURLToPath } from 'node:url';
 import * as esbuild from 'esbuild';
 
-const serviceWorkerSrc = fileURLToPath(new URL('../src/assets/service-worker.ts', import.meta.url));
-const serviceWorkerDist = fileURLToPath(new URL('../dist/service-worker.js', import.meta.url));
+const serviceWorkerSrc = fileURLToPath(new URL('../../src/assets/service-worker.ts', import.meta.url));
+const serviceWorkerDist = fileURLToPath(new URL('../../dist/service-worker.js', import.meta.url));
 
 export default function serviceWorkerIntegration(): AstroIntegration {
   return {
@@ -37,6 +37,7 @@ export default function serviceWorkerIntegration(): AstroIntegration {
         } catch (e) {
           console.error('Failed to build service worker');
           console.error(e);
+          process.exit(1);
         }
       },
     },

--- a/config/astro/service-worker-integration.ts
+++ b/config/astro/service-worker-integration.ts
@@ -1,9 +1,11 @@
 import type { APIRoute, AstroIntegration } from 'astro';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as esbuild from 'esbuild';
 
-const serviceWorkerSrc = fileURLToPath(new URL('../../src/assets/service-worker.ts', import.meta.url));
-const serviceWorkerDist = fileURLToPath(new URL('../../dist/service-worker.js', import.meta.url));
+const filenamePath = (filename: string) => fileURLToPath(new URL(join('../../', filename), import.meta.url));
+const srcFilename = filenamePath('src/assets/service-worker.ts');
+const outFilename = filenamePath('dist/service-worker.js');
 
 export default function serviceWorkerIntegration(): AstroIntegration {
   return {
@@ -16,7 +18,7 @@ export default function serviceWorkerIntegration(): AstroIntegration {
       }) => {
         const isDevelopment = command === 'dev';
         if (isDevelopment) {
-          addWatchFile(serviceWorkerSrc);
+          addWatchFile(srcFilename);
           injectRoute({
             pattern: '/service-worker.js',
             entrypoint: import.meta.url,
@@ -26,8 +28,8 @@ export default function serviceWorkerIntegration(): AstroIntegration {
       'astro:build:done': async () => {
         try {
           await esbuild.build({
-            entryPoints: [serviceWorkerSrc],
-            outfile: serviceWorkerDist,
+            entryPoints: [srcFilename],
+            outfile: outFilename,
             target: ['es2020'],
             bundle: true,
             minify: true,
@@ -46,8 +48,8 @@ export default function serviceWorkerIntegration(): AstroIntegration {
 
 export const GET: APIRoute = async () => {
   const output =  await esbuild.build({
-    entryPoints: [serviceWorkerSrc],
-    outdir: serviceWorkerDist,
+    entryPoints: [srcFilename],
+    outdir: outFilename,
     target: ['es2020'],
     bundle: true,
     minify: false,

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -40,3 +40,9 @@ import Icon from '@components/Icon/';
   }
 </style>
 ```
+
+## Service Worker
+
+Head Start provides a fully customisable service worker in [`src/assets/service-worker.ts`](../src/assets/service-worker.ts) that's automatically bundle and served as `/service-worker.js` (in both development and production) and registered in each web page (using inline script in `src/layouts/PerfHead`). The service worker uses the low-level [Workbox modules](https://developer.chrome.com/docs/workbox/modules) for fine-grained control.
+
+For more background see [decision log on service worker](./decision-log/2025-01-11-service-worker.md).

--- a/docs/decision-log/2025-01-11-service-worker.md
+++ b/docs/decision-log/2025-01-11-service-worker.md
@@ -1,0 +1,13 @@
+# Service Worker
+
+**Implement Service Worker using our own Astro Integration with Workbox modules for maximum control.**
+
+- Date: 2025-01-11
+- Alternatives Considered: existing integrations [`astrojs-service-worker`](https://github.com/tatethurston/astrojs-service-worker) and [`zastro-service-worker`](https://github.com/zachhandley/astro-service-worker)
+- Decision Made By: [Declan](https://github.com/decrek), [Jurgen](https://github.com/jurgenbelien), [Jasper](https://github.com/jbmoelker)
+
+## Decision
+
+Known existing Astro integrations for Service Workers are [`astrojs-service-worker`](https://github.com/tatethurston/astrojs-service-worker) and [`zastro-service-worker`](https://github.com/zachhandley/astro-service-worker). These integrations both use [`generateSW` from `workbox-build`](https://developer.chrome.com/docs/workbox/modules/workbox-build#generatesw), which only allows modifying the service worker through configuration.
+
+To give developers using Head Start more control over their service worker we've decided add our own [Astro Integration](../../config/astro/service-worker-integration.ts) which uses an actual file as a source ([`assets/service-worker.ts`](../../src/assets/service-worker.ts)) which developers can customise. By using low-level [Workbox modules](https://developer.chrome.com/docs/workbox/modules) this control is extended further.

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,11 @@
         "promise-all-props": "^3.0.0",
         "regexparam": "^3.0.0",
         "rosetta": "^1.1.0",
-        "typescript": "^5.7.3"
+        "typescript": "^5.7.3",
+        "workbox-cacheable-response": "^7.3.0",
+        "workbox-expiration": "^7.3.0",
+        "workbox-routing": "^7.3.0",
+        "workbox-strategies": "^7.3.0"
       },
       "devDependencies": {
         "@astrojs/ts-plugin": "^1.10.4",
@@ -11674,6 +11678,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -20566,6 +20576,49 @@
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/workbox-cacheable-response": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.3.0.tgz",
+      "integrity": "sha512-eAFERIg6J2LuyELhLlmeRcJFa5e16Mj8kL2yCDbhWE+HUun9skRQrGIFVUagqWj4DMaaPSMWfAolM7XZZxNmxA==",
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.3.0"
+      }
+    },
+    "node_modules/workbox-core": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.3.0.tgz",
+      "integrity": "sha512-Z+mYrErfh4t3zi7NVTvOuACB0A/jA3bgxUN3PwtAVHvfEsZxV9Iju580VEETug3zYJRc0Dmii/aixI/Uxj8fmw==",
+      "license": "MIT"
+    },
+    "node_modules/workbox-expiration": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.3.0.tgz",
+      "integrity": "sha512-lpnSSLp2BM+K6bgFCWc5bS1LR5pAwDWbcKt1iL87/eTSJRdLdAwGQznZE+1czLgn/X05YChsrEegTNxjM067vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "idb": "^7.0.1",
+        "workbox-core": "7.3.0"
+      }
+    },
+    "node_modules/workbox-routing": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.3.0.tgz",
+      "integrity": "sha512-ZUlysUVn5ZUzMOmQN3bqu+gK98vNfgX/gSTZ127izJg/pMMy4LryAthnYtjuqcjkN4HEAx1mdgxNiKJMZQM76A==",
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.3.0"
+      }
+    },
+    "node_modules/workbox-strategies": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.3.0.tgz",
+      "integrity": "sha512-tmZydug+qzDFATwX7QiEL5Hdf7FrkhjaF9db1CbB39sDmEZJg3l9ayDvPxy8Y18C3Y66Nrr9kkN1f/RlkDgllg==",
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.3.0"
+      }
     },
     "node_modules/workerd": {
       "version": "1.20250129.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,11 @@
     "promise-all-props": "^3.0.0",
     "regexparam": "^3.0.0",
     "rosetta": "^1.1.0",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "workbox-cacheable-response": "^7.3.0",
+    "workbox-expiration": "^7.3.0",
+    "workbox-routing": "^7.3.0",
+    "workbox-strategies": "^7.3.0"
   },
   "devDependencies": {
     "@astrojs/ts-plugin": "^1.10.4",

--- a/scripts/service-worker-integration.ts
+++ b/scripts/service-worker-integration.ts
@@ -1,0 +1,64 @@
+import type { APIRoute, AstroIntegration } from 'astro';
+import { fileURLToPath } from 'node:url';
+import * as esbuild from 'esbuild';
+
+const serviceWorkerSrc = fileURLToPath(new URL('../src/assets/service-worker.ts', import.meta.url));
+const serviceWorkerDist = fileURLToPath(new URL('../dist/service-worker.js', import.meta.url));
+
+export default function serviceWorkerIntegration(): AstroIntegration {
+  return {
+    name: 'service-worker',
+    hooks: {
+      'astro:config:setup': async ({
+        command,
+        injectRoute,
+        addWatchFile,
+      }) => {
+        const isDevelopment = command === 'dev';
+        if (isDevelopment) {
+          addWatchFile(serviceWorkerSrc);
+          injectRoute({
+            pattern: '/service-worker.js',
+            entrypoint: import.meta.url,
+          });
+        }
+      },
+      'astro:build:done': async () => {
+        try {
+          await esbuild.build({
+            entryPoints: [serviceWorkerSrc],
+            outfile: serviceWorkerDist,
+            target: ['es2020'],
+            bundle: true,
+            minify: true,
+            allowOverwrite: true,
+            sourcemap: true,
+          });
+        } catch (e) {
+          console.error('Failed to build service worker');
+          console.error(e);
+        }
+      },
+    },
+  };
+}
+
+export const GET: APIRoute = async () => {
+  const output =  await esbuild.build({
+    entryPoints: [serviceWorkerSrc],
+    outdir: serviceWorkerDist,
+    target: ['es2020'],
+    bundle: true,
+    minify: false,
+    write: false,
+    allowOverwrite: true,
+    sourcemap: false,
+  });
+
+  return new Response(output.outputFiles[0].contents, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/javascript',
+    },
+  });
+};

--- a/src/assets/service-worker.ts
+++ b/src/assets/service-worker.ts
@@ -1,31 +1,32 @@
 /// <reference lib="webworker" />
+declare const self: ServiceWorkerGlobalScope;
+export default null;
+
 import { registerRoute } from 'workbox-routing';
 import { NetworkFirst } from 'workbox-strategies';
 import { CacheableResponsePlugin } from 'workbox-cacheable-response';
 import { ExpirationPlugin } from 'workbox-expiration';
 
-((self: ServiceWorkerGlobalScope) => {
-  self.addEventListener('install', () => {
-    self.skipWaiting();
-  });
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
   
-  self.addEventListener('activate', (event) => {
-    event.waitUntil(self.clients.claim());
-  });
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
 
-  registerRoute(
-    ({ request }) => request.mode === 'navigate',
-    new NetworkFirst({
-      networkTimeoutSeconds: 3,
-      cacheName: 'pages',
-      plugins: [
-        new CacheableResponsePlugin({
-          statuses: [0, 200],
-        }),
-        new ExpirationPlugin({
-          maxEntries: 30,
-        }),
-      ],
-    })
-  );
-})(self as unknown as ServiceWorkerGlobalScope);
+registerRoute(
+  ({ request }) => request.mode === 'navigate',
+  new NetworkFirst({
+    networkTimeoutSeconds: 3,
+    cacheName: 'pages',
+    plugins: [
+      new CacheableResponsePlugin({
+        statuses: [0, 200],
+      }),
+      new ExpirationPlugin({
+        maxEntries: 30,
+      }),
+    ],
+  })
+);

--- a/src/assets/service-worker.ts
+++ b/src/assets/service-worker.ts
@@ -1,0 +1,31 @@
+/// <reference lib="webworker" />
+import { registerRoute } from 'workbox-routing';
+import { NetworkFirst } from 'workbox-strategies';
+import { CacheableResponsePlugin } from 'workbox-cacheable-response';
+import { ExpirationPlugin } from 'workbox-expiration';
+
+((self: ServiceWorkerGlobalScope) => {
+  self.addEventListener('install', () => {
+    self.skipWaiting();
+  });
+  
+  self.addEventListener('activate', (event) => {
+    event.waitUntil(self.clients.claim());
+  });
+
+  registerRoute(
+    ({ request }) => request.mode === 'navigate',
+    new NetworkFirst({
+      networkTimeoutSeconds: 3,
+      cacheName: 'pages',
+      plugins: [
+        new CacheableResponsePlugin({
+          statuses: [0, 200],
+        }),
+        new ExpirationPlugin({
+          maxEntries: 30,
+        }),
+      ],
+    })
+  );
+})(self as unknown as ServiceWorkerGlobalScope);

--- a/src/assets/service-worker.ts
+++ b/src/assets/service-worker.ts
@@ -2,15 +2,24 @@
 declare const self: ServiceWorkerGlobalScope;
 export default null;
 
-import { registerRoute } from 'workbox-routing';
-import { NetworkFirst } from 'workbox-strategies';
 import { CacheableResponsePlugin } from 'workbox-cacheable-response';
 import { ExpirationPlugin } from 'workbox-expiration';
+import { NetworkFirst } from 'workbox-strategies';
+import { registerRoute } from 'workbox-routing';
+import { setCacheNameDetails } from 'workbox-core';
+
+// be careful not to import the whole package.json, as it will be included in the final bundle
+import { name } from '@root/package.json';
 
 const STATUS_CODES = {
   Opaque: 0,
   OK: 200,
 } as const;
+
+setCacheNameDetails({
+  prefix: name,
+  suffix: 'v1',
+});
 
 self.addEventListener('install', () => {
   self.skipWaiting();

--- a/src/assets/service-worker.ts
+++ b/src/assets/service-worker.ts
@@ -7,6 +7,11 @@ import { NetworkFirst } from 'workbox-strategies';
 import { CacheableResponsePlugin } from 'workbox-cacheable-response';
 import { ExpirationPlugin } from 'workbox-expiration';
 
+const STATUS_CODES = {
+  Opaque: 0,
+  OK: 200,
+} as const;
+
 self.addEventListener('install', () => {
   self.skipWaiting();
 });
@@ -22,7 +27,7 @@ registerRoute(
     cacheName: 'pages',
     plugins: [
       new CacheableResponsePlugin({
-        statuses: [0, 200],
+        statuses: [STATUS_CODES.Opaque, STATUS_CODES.OK],
       }),
       new ExpirationPlugin({
         maxEntries: 30,

--- a/src/layouts/PerfHead/PerfHead.astro
+++ b/src/layouts/PerfHead/PerfHead.astro
@@ -8,6 +8,21 @@ const fontFaceDeclaration = fonts.map((font) => getFontFaceDeclaration(font)).jo
 ---
 
 {preConnectOrigins.map((origin) => <link rel="preconnect" href={origin} />)}
+
+<script is:inline>
+  window.addEventListener('load', () => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/service-worker.js')
+        .then((registration) => registration.update())
+        .catch((err) => {
+          console.log('Error while registering service worker');
+          console.log(err);
+        });
+    }
+  });
+</script>
+
 {
   woff2urls.map((url) => (
     <link


### PR DESCRIPTION
# Changes

- Add service worker setup with basic network first strategy on HTML pages
- Made the decision to go for my own custom integration. It can serve as an example integration and I like the fact that we build our own service worker from a service-worker.ts file instead of generating one. I feel this is the most understandable for others and gives you maximum freedom over its implementation.

# Associated issue

Resolves #199 

# How to test

1. Open preview link
2. Open devtools --> Application
3. Verify a service worker is installed
4. Go offline, refresh the page and verify that the HTML page is still served

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- [x] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [x] I have notified a reviewer
