### PR TITLE
chore: "analyze" script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules/
 .env.production
 
 # generated files
+reports/
 src/assets/icon-sprite.svg
 src/assets/icon-sprite.ts
 src/lib/datocms/types.ts

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ All commands are run from the root of the project, from a terminal:
 | `preview`               | Preview your build locally, before deploying
 | `astro ...`             | Run commands like `astro add` (see `astro -- --help`)
 | `create`                | Scaffold new Block, Component, API or Page route
+| `analyze`               | Analyze and visualise both client & server bundles
 | `lint`                  | Check code style and valide HTML output
 | `test`                  | Runs the test suite, individual tests are available using `test:...`
 

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -2,11 +2,13 @@ import { defineConfig, envField, passthroughImageService } from 'astro/config';
 import cloudflare from '@astrojs/cloudflare';
 import graphql from '@rollup/plugin-graphql';
 import sitemap from '@astrojs/sitemap';
+import Sonda from 'sonda/astro';
 import type { PluginOption } from 'vite';
 import { isPreview } from './config/preview';
 import pkg from './package.json';
 import serviceWorker from './config/astro/service-worker-integration.ts';
 
+const isAnalyseMode = process.env.ANALYZE === 'true';
 const productionUrl = `https://${ pkg.name }.pages.dev`; // overwrite if you have a custom domain
 const localhostPort = 4323; // 4323 is "head" in T9
 export const siteUrl = process.env.CF_PAGES
@@ -52,13 +54,21 @@ export default defineConfig({
     service: passthroughImageService()
   },
   integrations: [
+    serviceWorker(),
     sitemap(),
-    serviceWorker()
+    Sonda({
+      enabled: isAnalyseMode,
+      filename: 'reports/sonda-report-[env].html',
+      server: true,
+    }),
   ],
   output: isPreview ? 'server' : 'static',
   server: { port: localhostPort },
   site: siteUrl,
   vite: {
+    build: {
+      sourcemap: isAnalyseMode,
+    },
     plugins: [
       graphql() as PluginOption,
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "npm-run-all": "^4.1.5",
         "plop": "^4.0.0",
         "robots-parser": "^3.0.1",
+        "sonda": "^0.7.1",
         "svg-sprite": "^2.0.2",
         "vitest": "^3.0.5",
         "wrangler": "^3.23.0"
@@ -9033,6 +9034,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
@@ -17641,6 +17655,115 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/sonda": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/sonda/-/sonda-0.7.1.tgz",
+      "integrity": "sha512-PCdSdBvspoJXA0uY5GFeRzAolTHDP7gVnnMnr/O74IYIB8CiOFaEbTGNkEmShG6HBtmmFdQfPxdXbI+2vAgjYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "open": "^10.1.0"
+      },
+      "bin": {
+        "sonda-angular": "bin/sonda-angular.js"
+      }
+    },
+    "node_modules/sonda/node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sonda/node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sonda/node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sonda/node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sonda/node_modules/open": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sonda/node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "license": "ISC",
   "scripts": {
+    "analyze": "ANALYZE=true npm run build",
     "astro": "astro",
     "prebuild": "run-s prep",
     "build": "astro build",
@@ -96,6 +97,7 @@
     "npm-run-all": "^4.1.5",
     "plop": "^4.0.0",
     "robots-parser": "^3.0.1",
+    "sonda": "^0.7.1",
     "svg-sprite": "^2.0.2",
     "vitest": "^3.0.5",
     "wrangler": "^3.23.0"


### PR DESCRIPTION
# Changes

Adds npm script to visualise both client & server bundles using [Sonda](https://sonda.dev/frameworks/astro), 
so that developers can analyse their code output and optimise it.

**Example client bundle:**

![Screenshot 2025-01-06 at 17 50 14](https://github.com/user-attachments/assets/c78c2c53-575c-45b0-bf58-fd59fbe7f1c3)

**Example server bundle:**

![Screenshot 2025-01-06 at 17 50 06](https://github.com/user-attachments/assets/c9519520-bac9-4037-a519-9ce5df4c280b)

# Associated issue

N/A

# How to test

1. Check out this branch
2. Run `npm run analyze`
3. Verify the bundles are visualised in the browser

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- ~I have added a decision log entry if the change affects the architecture or changes a significant technology~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
