### PR TITLE
Fix Video Blocks in non Chromium browsers

### DIFF
--- a/src/blocks/VideoBlock/VideoBlock.client.ts
+++ b/src/blocks/VideoBlock/VideoBlock.client.ts
@@ -26,6 +26,10 @@ class VideoBlock extends HTMLElement {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation
    */
   #useDataSaveMode = (() => {
+    if (!('connection' in navigator)) {
+      return false;
+    }
+    
     type NetworkInformation = { saveData: boolean; }
     const connection = (navigator as unknown as { connection: NetworkInformation }).connection;
     return connection.saveData === true;


### PR DESCRIPTION
# Changes

add feature check for navigator.connection since it is chromium only making video blocks fail outside of chromium browsers

# Associated issue

Resolves #249 

# How to test

Test Video Block in non Chromium browser

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- ~I have made updated relevant documentation files (in project README, docs/, etc)~
- ~I have added a decision log entry if the change affects the architecture or changes a significant technology~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
