### PR TITLE
refactor: Type datocmsRequest based on output mode or prerender.

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -4,13 +4,15 @@ import graphql from '@rollup/plugin-graphql';
 import sitemap from '@astrojs/sitemap';
 import Sonda from 'sonda/astro';
 import type { PluginOption } from 'vite';
-import { isPreview } from './config/preview';
 import pkg from './package.json';
+import { isPreview } from './config/preview';
+import { output } from './config/output';
 import serviceWorker from './config/astro/service-worker-integration.ts';
 
 const isAnalyseMode = process.env.ANALYZE === 'true';
-const productionUrl = `https://${ pkg.name }.pages.dev`; // overwrite if you have a custom domain
+const productionUrl = `https://${pkg.name}.pages.dev`; // overwrite if you have a custom domain
 const localhostPort = 4323; // 4323 is "head" in T9
+
 export const siteUrl = process.env.CF_PAGES
   ? (process.env.CF_PAGES_BRANCH === 'main')
     ? productionUrl
@@ -62,7 +64,7 @@ export default defineConfig({
       server: true,
     }),
   ],
-  output: isPreview ? 'server' : 'static',
+  output: isPreview ? 'server' : output, // @see `/config/output.ts``
   server: { port: localhostPort },
   site: siteUrl,
   vite: {

--- a/config/output.ts
+++ b/config/output.ts
@@ -1,0 +1,13 @@
+import { type AstroUserConfig } from 'astro';
+
+/**
+ * Output mode for the Astro build process.
+ * - 'static': Pre-renders (SSG) all pages at build time into HTML files (default).
+ * - 'server': Use server-side rendering (SSR) for all pages by default, 
+ *    always outputting a server-rendered site.
+ * - The 'server' mode is used when preview mode is enabled, allowing dynamic SSR.
+ * Overriding individual pages to use SSR or SSG is possible by adding 
+ * `export const prerender = true // or false;` to a route.
+ * @see https://docs.astro.build/en/reference/configuration-reference/#output
+ */
+export const output = 'static' as const satisfies AstroUserConfig['output'];

--- a/src/lib/datocms/index.ts
+++ b/src/lib/datocms/index.ts
@@ -82,7 +82,7 @@ export async function datocmsRequest<
   return data;
 }
 
-interface CollectionData<CollectionType> {
+type CollectionData<CollectionType> = {
   [key: string]: CollectionType[];
 }
 
@@ -139,7 +139,7 @@ export async function datocmsCollection<CollectionType>({
     );
 
   for (let page = 0; page < totalPages; page++) {
-    const data = await datocmsRequest({
+    const data = await datocmsRequest<CollectionData<CollectionType>>({
       query: parse(/* graphql */`
         # Insert fragment definition from fragmentDocument, 
         # which is either the fragment passed from an import from @lib/datocms/types.ts 
@@ -155,7 +155,7 @@ export async function datocmsCollection<CollectionType>({
           }
         }
       `),
-    }) as CollectionData<CollectionType>;
+    });
 
     records.push(...data[collection]);
   }

--- a/src/lib/datocms/index.ts
+++ b/src/lib/datocms/index.ts
@@ -15,12 +15,17 @@ type DatocmsRequest = {
   variables?: { [key: string]: string };
   retryCount?: number;
 };
+
+type Assert<Query> = Required<{ [key in keyof Query]: NonNullable<Query[key]> }>;
+
 /**
  * Makes a request to the DatoCMS GraphQL API using the provided query and variables.
  * It has authorization, environment and drafts (preview) pre-configured.
  * It has a retry mechanism in case of rate-limiting, based on DatoCMS API utils. @see https://github.com/datocms/js-rest-api-clients/blob/f4e820d/packages/rest-client-utils/src/request.ts#L239C13-L255
  */
-export const datocmsRequest = async <T>({ query, variables = {}, retryCount = 1 }: DatocmsRequest): Promise<T> => {
+export const datocmsRequest = async <Query>(
+  { query, variables = {}, retryCount = 1 }: DatocmsRequest,
+): Promise<Assert<Query>> => {
   const headers = new Headers({
     Authorization: DATOCMS_READONLY_API_TOKEN,
     'Content-Type': 'application/json',

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -11,11 +11,13 @@ export const prerender = false;
 
 Astro.response.status = 404;
 
-const { locale } = Astro.params as { locale: SiteLocale };
-const { page } = (await datocmsRequest<NotFoundPageQuery>({
-  query,
-  variables: { locale },
-})) as { page: NonNullable<NotFoundPageQuery['page']> };
+type Params = {
+  locale: SiteLocale;
+};
+
+const { locale } = Astro.params as Params;
+const variables = { locale };
+const { page } = await datocmsRequest<NotFoundPageQuery>({ query, variables });
 ---
 
 <Layout pageUrls={[]} seoMetaTags={[noIndexTag, titleTag(page.title)]}>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -17,7 +17,8 @@ type Params = {
 
 const { locale } = Astro.params as Params;
 const variables = { locale };
-const { page } = await datocmsRequest<NotFoundPageQuery>({ query, variables });
+// While this page is not prerendered, we still want to treat it as a regular page with the default prerender strategy.
+const { page } = await datocmsRequest<NotFoundPageQuery, true>({ query, variables });
 ---
 
 <Layout pageUrls={[]} seoMetaTags={[noIndexTag, titleTag(page.title)]}>

--- a/src/pages/[locale]/[...path]/index.astro
+++ b/src/pages/[locale]/[...path]/index.astro
@@ -41,7 +41,7 @@ type Params = {
 
 const { locale, path } = Astro.params as Params;
 const variables = { locale, slug: getPageSlugFromPath(path) };
-const { page } = await datocmsRequest<PageQuery>({ query, variables });
+const { page } = await datocmsRequest<PageQuery /*, typeof prerender */>({ query, variables });
 const breadcrumbs = [...getParentPages(page), page].map((page) =>
   formatBreadcrumb({
     text: page.title,

--- a/src/pages/[locale]/[...path]/index.astro
+++ b/src/pages/[locale]/[...path]/index.astro
@@ -41,9 +41,7 @@ type Params = {
 
 const { locale, path } = Astro.params as Params;
 const variables = { locale, slug: getPageSlugFromPath(path) };
-const { page } = (await datocmsRequest<PageQuery>({ query, variables })) as {
-  page: NonNullable<PageQuery['page']>; // Only NonNullable when statically generated. Handle as a 404 when this is a server route!
-};
+const { page } = await datocmsRequest<PageQuery>({ query, variables });
 const breadcrumbs = [...getParentPages(page), page].map((page) =>
   formatBreadcrumb({
     text: page.title,

--- a/src/pages/[locale]/index.astro
+++ b/src/pages/[locale]/index.astro
@@ -15,10 +15,7 @@ export async function getStaticPaths() {
 
 const { locale } = Astro.params;
 const variables = { locale };
-const { page } = (await datocmsRequest<HomePageQuery>({
-  query,
-  variables,
-})) as { page: NonNullable<HomePageQuery['page']> };
+const { page } = await datocmsRequest<HomePageQuery>({ query, variables });
 const pageUrls = locales.map((locale) => ({
   locale,
   pathname: getHomeHref({ locale }),

--- a/src/pages/[locale]/index.astro
+++ b/src/pages/[locale]/index.astro
@@ -15,7 +15,7 @@ export async function getStaticPaths() {
 
 const { locale } = Astro.params;
 const variables = { locale };
-const { page } = await datocmsRequest<HomePageQuery>({ query, variables });
+const { page } = await datocmsRequest<HomePageQuery /*, typeof prerender */>({ query, variables });
 const pageUrls = locales.map((locale) => ({
   locale,
   pathname: getHomeHref({ locale }),

--- a/src/pages/[locale]/search/opensearch.xml.ts
+++ b/src/pages/[locale]/search/opensearch.xml.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { locales } from '@lib/i18n';
 import { datocmsRequest } from '@lib/datocms';
-import type { OpenSearchXmlQuery, Site } from '@lib/datocms/types';
+import type { OpenSearchXmlQuery } from '@lib/datocms/types';
 import { getSearchPathname, getOpenSearchName, queryParamName } from '@lib/search';
 import query from './_opensearch.query.graphql';
 
@@ -34,7 +34,7 @@ const openSearchXml = (
 
 export const GET: APIRoute = async ({ params, site }) => {
   const locale = params.locale!;
-  const data = await datocmsRequest<OpenSearchXmlQuery>({ query, variables: { locale } }) as { site: Site };
+  const data = await datocmsRequest<OpenSearchXmlQuery>({ query, variables: { locale } });
   const { favicon, globalSeo } = data.site;
   const searchPageUrl = `${ site!.origin }${ getSearchPathname(locale) }`;
 


### PR DESCRIPTION
In order to cut down on type assertion via `as`, `datocmsRequest` should return a more workable type definition. Based on a passed type variable – or when omitted, the value of `output` in the astro config – `datocmsRequest` either has a return type that assumes the resource is available, or passes the expected return value based on the query.

# Changes

- Export output mode from astro config.
- Allow asserted type override of datocmsRequest via `AssertReturnType`. 

# How to test

1. Check out code locally
2. Open `@pages/[locale]/[...path]/index.astro`
3. Verify that the return value of `datocmsRequest` is typed by `PageQuery`, without any type assertion.
4. Replace comment `/* typeof prerender */` with a `true` or `false` value in the `datocmsRequest` type variables. 
5. Verify that any mention of `page` gets TypeScript errors.
6. Remove the manipulated type varable.
7. See that the TypeScript errors disappear.
8. Change the output mode in `config/output.ts`;
5. Verify that the TypeScript errors return.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] ~I have made updated relevant documentation files (in project README, docs/, etc)~
- [ ] ~I have added a decision log entry if the change affects the architecture or changes a significant technology~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
