### PR TITLE
feat(StructuredText): safer extraction of node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "accept-language-parser": "^1.5.0",
         "astro": "^5.2.4",
         "datocms-listen": "^0.1.15",
-        "datocms-structured-text-utils": "^2.0.4",
+        "datocms-structured-text-utils": "^4.0.1",
         "get-video-id": "^3.6.5",
         "globby": "^13.2.2",
         "hls.js": "^1.5.2",
@@ -8875,9 +8875,9 @@
       }
     },
     "node_modules/datocms-structured-text-utils": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/datocms-structured-text-utils/-/datocms-structured-text-utils-2.1.12.tgz",
-      "integrity": "sha512-tZtiPN/sEjl+4Z6igojPdap6Miy0Z6VO6Afor3vcyY/8PIwKVGbTsdd5trD+skWPCPRZVNzKpfYoAVziXWTL8Q==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/datocms-structured-text-utils/-/datocms-structured-text-utils-4.1.2.tgz",
+      "integrity": "sha512-xyBG7ZAXedv8wytTR1JqfHx8uuUogg6I9brQmK1uR3y14gQqTRLvAeoY3unp5xcBDm8YXYHdS2W+Bg9AWgdhLQ==",
       "license": "MIT",
       "dependencies": {
         "array-flatten": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "accept-language-parser": "^1.5.0",
     "astro": "^5.2.4",
     "datocms-listen": "^0.1.15",
-    "datocms-structured-text-utils": "^2.0.4",
+    "datocms-structured-text-utils": "^4.0.1",
     "get-video-id": "^3.6.5",
     "globby": "^13.2.2",
     "hls.js": "^1.5.2",

--- a/src/components/StructuredText/StructuredText.astro
+++ b/src/components/StructuredText/StructuredText.astro
@@ -1,19 +1,26 @@
 ---
 // based on https://github.com/datocms/datocms-svelte/blob/main/src/lib/components/StructuredText/StructuredText.svelte
-import { isStructuredText } from 'datocms-structured-text-utils';
-import type { Document, Node as NodeType, StructuredText } from 'datocms-structured-text-utils';
+import { isDocument, isNode, isStructuredText } from 'datocms-structured-text-utils';
+import type * as STU from 'datocms-structured-text-utils';
 import type { PredicateComponentTuple } from './StructuredText';
 import Node from './Node.astro';
 
 interface Props {
-  data: StructuredText | Document | null;
+  data: STU.StructuredText | STU.Document | null;
   components?: PredicateComponentTuple[];
 }
 
 const { data = null, components = [] } = Astro.props;
-const node = (data != null && (isStructuredText(data) ? data.value : data).document) as NodeType;
+
+const node = (() => {
+  if (!data) return null;
+  if (isStructuredText(data) && isDocument(data.value)) return data.value.document;
+  if (isDocument(data)) return data.document;
+  if (isNode(data)) return data;
+  return null;
+})() satisfies STU.Node | null;
 const blocks = isStructuredText(data) ? data?.blocks : undefined;
 const links =  isStructuredText(data) ? data?.links : undefined;
 ---
 
-<Node {node} {blocks} {links} {components} />
+{node && <Node {node} {blocks} {links} {components} />}


### PR DESCRIPTION
# Changes

- Upgrades `datocms-structured-text-utils` to newer version
- Safer extraction of node
- Typescript `satisfies` for return type validation.

# How to test

1. Open preview link
2. Browse docs,
3. See that pages are still rendered

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] ~I have made updated relevant documentation files (in project README, docs/, etc)~
- [ ] ~I have added a decision log entry if the change affects the architecture or changes a significant technology~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
