### PR TITLE
feat: more helpful errors when blocks are missing

### DIFF
--- a/src/blocks/Blocks.astro
+++ b/src/blocks/Blocks.astro
@@ -1,4 +1,5 @@
 ---
+import { PUBLIC_IS_PRODUCTION } from 'astro:env/server';
 import type { AnyBlock } from './Blocks';
 import ActionBlock from './ActionBlock/ActionBlock.astro';
 import EmbedBlock from './EmbedBlock/EmbedBlock.astro';
@@ -26,19 +27,28 @@ interface Props {
   blocks: AnyBlock[];
 }
 const { blocks } = Astro.props;
+
+const raise = (message: string) => {
+  if (!PUBLIC_IS_PRODUCTION) {
+    console.error(message);
+  }
+  return message;
+};
 ---
 
 {
   blocks.map((block) => {
-    const typename = block.__typename as keyof typeof blocksByTypename;
-    const Block = blocksByTypename[typename];
-    return Block ? (
-      // @ts-ignore next line
-      <Block block={block} />
-    ) : (
-      <script define:vars={{ typename }} is:inline>
-        console.log(`No Block found for "${typename}"`);
-      </script>
-    );
+    const { __typename, ...rest } = block;
+    if (!Object.keys(rest).length) {
+      const message = raise(`No block data found for "${__typename}". Is the associated fragment included in the query?`);
+      return <script define:vars={{ message }} is:inline>console.log(message);</script>;
+    }
+    const Block = blocksByTypename[__typename as keyof typeof blocksByTypename];
+    if (!Block) {
+      const message = raise(`No block data found for "${__typename}". Is it included in ${import.meta.filename}?`);
+      return <script define:vars={{ message }} is:inline>console.log(message);</script>;
+    }
+    //@ts-expect-error - since block can be any block its type is conflated to `never`.
+    return <Block block={block} />;
   })
 }


### PR DESCRIPTION
Report on possible issues that can occur when a new block is not added correctly.
# Changes

- Check if there are fields other than `__typename` are passed for a specific block. If not, the block is probably missing in the query.
- Check if an Astro component is found for `__typename`. If not, the component is probably not added to the `blocksByTypename` map. 
- Better Typescript suppression
- More helpful hint
- Logging on server side when in development.


# How to test

1. Check out & run the project locally
2. Go to the query.graphql for the home page.
3. Remove the TextBlockRecord spread
4. Visit the homepage.
5. Verify that you see `No block data found for "TextBlockRecord". Is the associated fragment included in the query?` in both your terminal and the browser console.
6. Remove the `TextBlockRecord` entry in @blocks/Blocks.astro`
7. Visit the homepage.
8. Verify that you see `No block data found for "TextBlockRecord". Is it included in <path to file>?` in both your terminal and the browser console.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] ~I have made updated relevant documentation files (in project README, docs/, etc)~
- [ ] ~I have added a decision log entry if the change affects the architecture or changes a significant technology~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
