### PR TITLE
refactor: allow string type in setLocale; mock locales in tests

### DIFF
--- a/src/lib/datocms/tests/datocmsSearch.test.ts
+++ b/src/lib/datocms/tests/datocmsSearch.test.ts
@@ -1,15 +1,8 @@
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  test,
-  vi,
-} from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi, } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { datocmsSearch } from '@lib/datocms';
+import type { SiteLocale } from '@lib/datocms/types.ts';
 
 vi.mock('../../../../datocms-environment', () => ({
   datocmsBuildTriggerId: 'mock-build-trigger-id',
@@ -32,6 +25,8 @@ const mockedSearchResults = [
     },
   }
 ];
+
+const mockLocales = ['en', 'nl'] as SiteLocale[];
 
 const server = setupServer();
 
@@ -92,17 +87,13 @@ describe('datocmsSearch:', () => {
       })
     );
 
-    await datocmsSearch({ locale: 'en', query: 'test' });
-    expect(requestUrl).toBeDefined();
-    expect(requestUrl!.searchParams.get('locale')).toBe('en');
-    expect(requestUrl!.searchParams.get('q')).toBe('test');
-    expect(requestUrl!.searchParams.get('build_trigger_id')).toBe('mock-build-trigger-id');
-
-    await datocmsSearch({ locale: 'nl', query: 'my mock query' });
-    expect(requestUrl).toBeDefined();
-    expect(requestUrl!.searchParams.get('locale')).toBe('nl');
-    expect(requestUrl!.searchParams.get('q')).toBe('my mock query');
-    expect(requestUrl!.searchParams.get('build_trigger_id')).toBe('mock-build-trigger-id');
+    for (const locale of mockLocales) {
+      await datocmsSearch({ locale, query: 'test' });
+      expect(requestUrl).toBeDefined();
+      expect(requestUrl!.searchParams.get('locale')).toBe(locale);
+      expect(requestUrl!.searchParams.get('q')).toBe('test');
+      expect(requestUrl!.searchParams.get('build_trigger_id')).toBe('mock-build-trigger-id');
+    }
   });
 
   test('should handle fuzzy search correctly', async () => {

--- a/src/lib/datocms/tests/datocmsSearch.test.ts
+++ b/src/lib/datocms/tests/datocmsSearch.test.ts
@@ -1,4 +1,12 @@
-import { afterAll, afterEach, beforeAll, describe, expect, test, vi, } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { datocmsSearch } from '@lib/datocms';

--- a/src/lib/i18n/index.test.ts
+++ b/src/lib/i18n/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { defaultLocale, t, getLocale, getLocaleName, setLocale } from '@lib/i18n';
+import { defaultLocale, getLocale, getLocaleName, setLocale, t } from '@lib/i18n';
 
 // these imports will resolve to their mocked counterparts
 import { locales } from '@lib/site.json';
@@ -64,7 +64,6 @@ describe('i18n:', () => {
       // expect 'nl' because the locale was most recently set to 'nl'
       expect(setLocale()).toBe('nl');
 
-      // @ts-expect-error we know that 'unsupported_locale' is not a supported locale
       expect(setLocale('unsupported_locale')).not.toBe('unsupported_locale');
     });
   });

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -29,8 +29,12 @@ export function getLocale() {
   return i18n.locale();
 }
 
-export function setLocale(locale?: SiteLocale) {
-  if (locale && locales.includes(locale)) {
+export function isLocale<T extends typeof locales>(locale: unknown): locale is T[number] {
+  return Boolean(locale) && (locales as unknown[]).includes(locale);
+}
+
+export function setLocale(locale?: string) {
+  if (isLocale(locale)) {
     return i18n.locale(locale);
   }
   return i18n.locale();


### PR DESCRIPTION
Adds type-guard for locale and updates setLocale and tests with type-guard in place.
This allows tests relying on the locale to run with mock locales but provides type guard functions that assert strings to be a locale when passing.
Consider the following example in a function;
```ts
const locale = 'non-existent-locale';
if (!isLocale(locale)) return;
locales.includes(locale)
```
With `isLocale()`, the locale variable is now asserted to be a locale when the check passes, without linting errors when using a non existent locale.
Initially Typescript would assert locales.includes to contain an error during linting, resulting in head-start projects test/lint CI to fail when not all locales are present in the corresponding dato instance.
# Changes
- Adds `isLocale()` type-guard
- Updates `setLocale()` signature to accept any string
- Updates `datocmsSearch.test.ts` to map over mock locales that are cast to SiteLocales as the test does not need to rely on existing locales


# How to test

1. CI lint/test

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] ~I have made updated relevant documentation files (in project README, docs/, etc)~
- [x] ~I have added a decision log entry if the change affects the architecture or changes a significant technology~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
