### PR TITLE
fix(routing): add id to Home for StructuredText link

### DIFF
--- a/src/components/LinkToRecord/LinkToRecord.test.ts
+++ b/src/components/LinkToRecord/LinkToRecord.test.ts
@@ -4,8 +4,9 @@ import type { RecordRoute } from '@lib/routing';
 import LinkToRecord, { type Props as LinkToRecordProps } from './LinkToRecord.astro';
 
 const record = {
-  title: 'Homepage',
   __typename: 'HomePageRecord',
+  id: 'home',
+  title: 'Homepage',
 } satisfies RecordRoute;
 
 const props = {

--- a/src/lib/routing/HomeRoute.fragment.graphql
+++ b/src/lib/routing/HomeRoute.fragment.graphql
@@ -1,4 +1,5 @@
 fragment HomeRoute on HomePageRecord {
   __typename
+  id
   title
 }

--- a/src/lib/routing/index.test.ts
+++ b/src/lib/routing/index.test.ts
@@ -27,6 +27,7 @@ const fileRecord: FileRouteFragment = {
 
 const homeRecord: HomeRouteFragment = { 
   __typename: 'HomePageRecord',
+  id: 'home',
   title: 'Home'
 };
 


### PR DESCRIPTION
# Changes

- Add `id` to HomeRouteFragment


# How to test

1. Visit this page https://head-start.pages.dev/en/link-to-home-test
2. Verify that you get an error page (looks like a 404, but trust me, it's an error page)
3. Visit this page https://fix-home-route-id.head-start.pages.dev/en/link-to-home-test
4. Verify that you get a page with a link to Home.

# Checklist

- [X] I have performed a self-review of my own code
- [X] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] ~I have made updated relevant documentation files (in project README, docs/, etc)~
- [x] ~I have added a decision log entry if the change affects the architecture or changes a significant technology~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
