### PR TITLE
Feat: add custom text styles plugin

### DIFF
--- a/config/datocms/migrations/1748357537_pluginCustomTextStyles.ts
+++ b/config/datocms/migrations/1748357537_pluginCustomTextStyles.ts
@@ -1,0 +1,27 @@
+import { Client } from '@datocms/cli/lib/cma-client-node';
+
+export default async function (client: Client) {
+  console.log('Manage upload filters');
+
+  console.log('Install plugin "Custom Text Styles"');
+  
+  const pluginCustomTextStyles = await client.plugins.create({
+    package_name: 'datocms-plugin-custom-text-styles',
+  });
+  await client.plugins.update(pluginCustomTextStyles.id, {
+    parameters: {
+      customStyles: [
+        {
+          css: 'text-align: center;',
+          slug: 'centered',
+          nodes: [
+            { label: 'Paragraph', value: 'paragraph' },
+            { label: 'Heading', value: 'heading' },
+          ],
+          title: 'Centered',
+          isOpen: true,
+        },
+      ],
+    },
+  });
+}

--- a/datocms-environment.ts
+++ b/datocms-environment.ts
@@ -3,5 +3,5 @@
  * @see docs/getting-started.md on how to use this file
  * @see docs/decision-log/2023-10-24-datocms-env-file.md on why file is preferred over env vars
  */
-export const datocmsEnvironment = 'translation-plugin';
+export const datocmsEnvironment = 'plugin-custom-text-styles';
 export const datocmsBuildTriggerId = '34548';

--- a/src/blocks/TextBlock/README.md
+++ b/src/blocks/TextBlock/README.md
@@ -11,3 +11,4 @@
 - Renders nested blocks using [`<Blocks />`](../Blocks.astro), so it supports any Block.
 - Renders internal links using [`<LinkToRecord />`](../../components/LinkToRecord/LinkToRecord.astro).
 - Renders headings with a custom component to avoid having multiple H1's on the page.
+- Passes [Custom Text Styles](https://github.com/voorhoede/datocms-plugin-custom-text-styles) defined in DatoCMS to the appropriate nodes so they can be styled with CSS.

--- a/src/blocks/TextBlock/TextBlock.test.ts
+++ b/src/blocks/TextBlock/TextBlock.test.ts
@@ -90,4 +90,50 @@ describe('TextBlock Component', () => {
     expect(fragment.querySelector('h3')?.textContent).toBe('This is a test heading');
     expect(fragment.querySelector('p')?.textContent).toBe('This is a test paragraph');
   });
+  
+  test('renders custom style as a class name', async () => {
+    const fragment = await renderToFragment<Props>(TextBlock, {
+      props: {
+        block: {
+          __typename: 'TextBlockRecord',
+          text: {
+            blocks: [],
+            links: [],
+            value: {
+              schema: 'dast',
+              document: {
+                type: 'root',
+                children: [
+                  {
+                    type: 'heading',
+                    style: 'centered',
+                    level: 3,
+                    children: [
+                      {
+                        type: 'span',
+                        value: 'This is a test heading'
+                      }
+                    ]
+                  },
+                  {
+                    type: 'paragraph',
+                    style: 'centered',
+                    children: [
+                      {
+                        type: 'span',
+                        value: 'This is a test paragraph'
+                      },
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect(fragment.querySelector('h3')?.classList).toContain('centered');
+    expect(fragment.querySelector('p')?.classList).toContain('centered');
+  });
 });

--- a/src/blocks/TextBlock/nodes/Heading.astro
+++ b/src/blocks/TextBlock/nodes/Heading.astro
@@ -16,3 +16,9 @@ const level = Math.max(minimumLevel, (nodeLevel || defaultLevel));
 const Tag = `h${level}` as 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 ---
 <Tag class={style}><slot /></Tag>
+
+<style>
+  .centered {
+    text-align: center;
+  }
+</style>

--- a/src/blocks/TextBlock/nodes/Heading.astro
+++ b/src/blocks/TextBlock/nodes/Heading.astro
@@ -7,11 +7,12 @@ interface Props {
 
 const { node } = Astro.props;
 
+const { style, level: nodeLevel } = node;
 // H1 is reserved for the page title, so we start at H2
 const minimumLevel = 2;
 const defaultLevel = 2;
-const level = Math.max(minimumLevel, (node.level || defaultLevel));
+const level = Math.max(minimumLevel, (nodeLevel || defaultLevel));
 
-const Tag = `h${level}`;
+const Tag = `h${level}` as 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 ---
-<Tag><slot /></Tag>
+<Tag class={style}><slot /></Tag>

--- a/src/components/StructuredText/Nodes/Heading.astro
+++ b/src/components/StructuredText/Nodes/Heading.astro
@@ -10,3 +10,9 @@ const { style, level = 2 } = node;
 const Tag = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 ---
 <Tag class={style}><slot /></Tag>
+
+<style>
+  .centered {
+    text-align: center;
+  }
+</style>

--- a/src/components/StructuredText/Nodes/Heading.astro
+++ b/src/components/StructuredText/Nodes/Heading.astro
@@ -6,7 +6,7 @@ interface Props {
 }
 
 const { node } = Astro.props;
-const { level = 2 } = node;
-const Tag = `h${level}`;
+const { style, level = 2 } = node;
+const Tag = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 ---
-<Tag><slot /></Tag>
+<Tag class={style}><slot /></Tag>

--- a/src/components/StructuredText/Nodes/Paragraph.astro
+++ b/src/components/StructuredText/Nodes/Paragraph.astro
@@ -1,1 +1,12 @@
-<p><slot /></p>
+---
+import type { Paragraph } from 'datocms-structured-text-utils';
+
+interface Props {
+  node: Paragraph;
+}
+
+const { node } = Astro.props;
+const { style } = node;
+---
+
+<p class={style}><slot /></p>

--- a/src/components/StructuredText/Nodes/Paragraph.astro
+++ b/src/components/StructuredText/Nodes/Paragraph.astro
@@ -10,3 +10,9 @@ const { style } = node;
 ---
 
 <p class={style}><slot /></p>
+
+<style>
+  .centered {
+    text-align: center;
+  }
+</style>

--- a/src/components/StructuredText/README.md
+++ b/src/components/StructuredText/README.md
@@ -4,6 +4,7 @@
 
 > [!NOTE]
 > This component is based on the [`StructuredText` component from `@datocms/svelte`](https://github.com/datocms/datocms-svelte/tree/main/src/lib/components/StructuredText) (there currently is no official DatoCMS Astro package available). The documentation and examples below are also borrowed and adapted from the Svelte version.
+Changes have been added to support the [Custom Text Styles plugin](https://github.com/voorhoede/datocms-plugin-custom-text-styles).
 
 ## Setup
 


### PR DESCRIPTION
# Changes

- Adds custom text styles with two example text style for paragraph and header
- Passes the style name as a class name to the Structured Text nodes
- Adds tests to verify if style is added

# Associated issue

# How to test

1. Open preview link
2. Navigate to Text Block demo
3. Verify that example for custom text styles is center aligned

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] ~I have added a decision log entry if the change affects the architecture or changes a significant technology~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
