### PR TITLE
feature: runtime security headers

### DIFF
--- a/datocms-environment.ts
+++ b/datocms-environment.ts
@@ -3,5 +3,5 @@
  * @see docs/getting-started.md on how to use this file
  * @see docs/decision-log/2023-10-24-datocms-env-file.md on why file is preferred over env vars
  */
-export const datocmsEnvironment = 'grouping-block';
+export const datocmsEnvironment = 'translation-plugin';
 export const datocmsBuildTriggerId = '34548';

--- a/public/_headers
+++ b/public/_headers
@@ -2,7 +2,9 @@
 # @see docs: https://developers.cloudflare.com/pages/platform/headers/
 
 # Headers for basic security
-# Project can be further secured with a Permissions Policy and Content Security Policy (CSP)
+# ℹ️ Project can be further secured with a Permissions Policy and Content Security Policy (CSP)
+# ⚠️ These headers are only applied to static files, so keep these rules in sync
+#    with their runtime counterparts in src/middleware/security-headers.ts
 /*
   Referrer-Policy: no-referrer-when-downgrade
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -5,11 +5,13 @@ import { i18n } from './i18n';
 import { preview } from './preview';
 import { proxyFiles } from './proxy-files';
 import { redirects } from './redirects';
+import { securityheaders } from './security-headers';
 
 export const onRequest = sequence(
   datocms,
   i18n,
   preview,
   proxyFiles,
-  redirects
+  redirects,
+  securityheaders,
 );

--- a/src/middleware/security-headers.ts
+++ b/src/middleware/security-headers.ts
@@ -1,0 +1,27 @@
+import { defineMiddleware } from 'astro:middleware';
+
+/**
+ * Security Headers:
+ * ⚠️ These headers are only applied to runtime responses, so keep these rules in sync 
+ *    with their static counterparts in public/_headers
+ * 
+ * Can be teste with: https://securityheaders.com/
+ */
+export const securityheaders = defineMiddleware(async (_, next) => {
+  const response = await next();
+  const headers = {
+    'Referrer-Policy': 'no-referrer-when-downgrade',
+    'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
+    'X-Content-Type-Options': 'nosniff',
+    'X-Frame-Options': 'SAMEORIGIN',
+    'X-XSS-Protection': '1; mode=block',
+  };
+  
+  // Apply security headers to the response if they are not already set
+  for (const [key, value] of Object.entries(headers)) {
+    if (!response.headers.has(key)) {
+      response.headers.set(key, value);
+    }
+  }
+  return response;
+});

--- a/src/middleware/tests/security-headers.test.ts
+++ b/src/middleware/tests/security-headers.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { APIContext } from 'astro';
+import { securityheaders } from '../security-headers';
+
+describe('securityheaders middleware', () => {
+  it('adds security headers to the response', async () => {
+    // Mock a minimal Astro middleware context
+    const mockRequest = new Request('https://example.com');
+    const mockContext = {
+      request: mockRequest,
+      params: {},
+    } as APIContext;
+
+    // Mock next() to return a Response without the headers
+    const response = new Response('OK');
+    const next = vi.fn().mockResolvedValue(response);
+
+    const finalResponse = await securityheaders(mockContext, next);
+
+    const expectedHeaders = {
+      'Referrer-Policy': 'no-referrer-when-downgrade',
+      'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'SAMEORIGIN',
+      'X-XSS-Protection': '1; mode=block',
+    };
+
+    expect(finalResponse).toBeInstanceOf(Response);
+    // Make sure all expected headers are set
+    for (const [key, expectedValue] of Object.entries(expectedHeaders)) {
+      expect(finalResponse?.headers.get(key)).toBe(expectedValue);
+    }
+  });
+
+  it('does not override existing headers', async () => {
+    const mockRequest = new Request('https://example.com');
+    const mockContext = {
+      request: mockRequest,
+      params: {},
+    } as APIContext;
+
+    const response = new Response('OK', {
+      headers: {
+        'X-Frame-Options': 'DENY', // Simulate an already-set header
+      },
+    });
+    const next = vi.fn().mockResolvedValue(response);
+
+    const finalResponse = await securityheaders(mockContext, next);
+
+    expect(finalResponse).toBeInstanceOf(Response);
+    // Make sure existing header is preserved
+    expect(finalResponse?.headers.get('X-Frame-Options')).toBe('DENY');
+    // Make sure others are still added
+    expect(finalResponse?.headers.get('X-Content-Type-Options')).toBe('nosniff');
+  });
+});


### PR DESCRIPTION
# Changes

#72 added basic security headers that are only applied to static files. This change adds the same security headers to runtime responses using Astro middleware.

# Associated issue

Relates to #72 and #56.

# How to test

1. Open Network tab in DevTools
2. [Open preview link](https://feat-runtime-security-headers.head-start.pages.dev/en/)
3. Go to a server-rendered page like [search](https://feat-runtime-security-headers.head-start.pages.dev/en/search/)
4. Verify responses have [headers configured in this PR]()
5. Check and compare tests under [changes section above](#changes)
6. Verify security report improved from D to B. 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc) -> inline
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
