### PR TITLE
Update to custom-text-styles plugin

### DIFF
--- a/datocms-environment.ts
+++ b/datocms-environment.ts
@@ -3,5 +3,5 @@
  * @see docs/getting-started.md on how to use this file
  * @see docs/decision-log/2023-10-24-datocms-env-file.md on why file is preferred over env vars
  */
-export const datocmsEnvironment = 'plugin-custom-text-styles';
+export const datocmsEnvironment = 'update-plugin-custom-text-styles';
 export const datocmsBuildTriggerId = '34548';

--- a/src/components/StructuredText/Nodes/Span.astro
+++ b/src/components/StructuredText/Nodes/Span.astro
@@ -7,15 +7,45 @@ interface Props {
 
 const { node } = Astro.props;
 
-const elementByMark: Record<DefaultMark, string> = {
+type Tag = 'span' | 'strong' | 'em' | 'del' | 'mark' | 'code' | 'u';
+
+const elementByMark: Record<string | DefaultMark, Tag> = {
   strong: 'strong',
   code: 'code',
   emphasis: 'em',
   underline: 'u',
   strikethrough: 'del',
   highlight: 'mark',
+
+  // Add custom marks set in custom-text-styles plugin
+  spoiler: 'span',
+  shout: 'strong',
 };
 
-const Tags = (node.marks as DefaultMark[])?.map(mark => elementByMark[mark] || 'span') || [];
+const Tags: { Tag: Tag; mark: string }[] =
+  node.marks?.map((mark) => {
+    const Tag = elementByMark[mark] || 'span';
+    return { Tag: Tag, mark };
+  }) || [];
 ---
-{Tags.reduce((children, Tag) => <Tag>{children}</Tag>, node.value)}
+
+{
+  Tags.reduce(
+    (children, { Tag, mark }) => <Tag class={mark}>{children}</Tag>,
+    node.value
+  )
+}
+
+<style>
+  .spoiler {
+    transition: color 0.3s ease-in-out;
+    color: black;
+    background-color: black;
+  }
+  .spoiler:hover {
+    color: white;
+  }
+  .shout {
+    text-transform: uppercase;
+  }
+</style>


### PR DESCRIPTION
** NEEDS TO BE UPDATED AFTER PLUGIN IS UPDATED to 2.0.0**

## Changes

- add feature of inline styling set in the new custom text styles plugin
- see https://github.com/voorhoede/datocms-plugin-custom-text-styles/pull/8 for more info on the update of the plugin

## TODO
write migration to newer version of plugin after its been released. 

# Associated issue

<!-- example:
Resolves #(ticket number)
-->

# How to test

<!-- example:
1. Open preview link
2. Navigate to ...
3. Tap on ...
4. Verify that ...
5. Etc ...
-->

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [ ] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
