### PR TITLE
feature: page partials content collection

### DIFF
--- a/.graphqlrc.ts
+++ b/.graphqlrc.ts
@@ -29,12 +29,13 @@ module.exports = {
             'typescript-operations',
             '@graphql-codegen/typescript-document-nodes',
           ],
-          /**
-          * scalar config borrowed from DatoCMS team:
-          * @see https://github.com/Tonel/typescript-type-generation-graphql-example/blob/2d43584b1d75c9086c4ddd594a6b2401a29b0055/graphql.config.yml#L11-L23
-          */
           config: {
+            enumsAsConst: true,
             strictScalars: true,
+            /**
+            * scalar config borrowed from DatoCMS team:
+            * @see https://github.com/Tonel/typescript-type-generation-graphql-example/blob/2d43584b1d75c9086c4ddd594a6b2401a29b0055/graphql.config.yml#L11-L23
+            */
             scalars: {
               BooleanType: 'boolean',
               CustomData: 'Record<string, unknown>',

--- a/docs/cms-data-loading.md
+++ b/docs/cms-data-loading.md
@@ -2,6 +2,8 @@
 
 **Head Starts provides loaders and helpers to fetch content from DatoCMS.**
 
+In most cases you want to fetch content per page via GraphQL queries, as is described below. In some cases however, you might want to use Astro's Content Collections. See the [documentation on Content Collections](./content-collections.md) to learn how it is implemented in Head Start.
+
 ## Configuration
 
 Head Start supports the use of [primary and sandbox environments in DatoCMS](https://www.datocms.com/docs/scripting-migrations/introduction). This enables feature branches to use a different environment than the main branch. You need to set the DatoCMS environment where content should be fetched from in [`/datocms-environment.ts`](../datocms-environment.ts):

--- a/docs/content-collections.md
+++ b/docs/content-collections.md
@@ -1,0 +1,10 @@
+# Astro Content Collections
+
+Astro's Content Collections allows you to prepare a dataset on build time to query it later in your templates. This means it can also act als a caching layer. View the [Astro documentation](https://docs.astro.build/en/guides/content-collections/) for more information.
+
+Like Astro Content Collections `src/content/config.ts` is used to define the collections. And like Astro, Head Start uses the `getCollection()` and `getEntry()` functions to retrieve data from these collections, but you should use the `@lib/content` module instead of `astro:content`.
+
+## Differences from Astro's Content Collections
+Head Start's Content Collections are similar to Astro's, but with some differences:
+* `getEntry` returns live data in development and preview environments.
+* `getCollection` and `getEntry` support localized data. Any lookup will first try to search by the current locale, but you can also pass a `locale` parameter to specify a different locale.

--- a/scripts/download-translations.ts
+++ b/scripts/download-translations.ts
@@ -31,8 +31,7 @@ async function downloadTranslations() {
   const locales = Object.keys(translations);
   const translationKeys = Object.keys(translations[locales[0]]);
   await writeFile('./src/lib/i18n/types.ts',
-    `export type TranslationKey = \n | ${translationKeys.map(key => `'${key}'`).join('\n | ')};\n` +
-    `export type SiteLocale = \n | ${locales.map(locale => `'${locale}'`).join('\n | ')};\n`
+    `export type TranslationKey = \n | ${translationKeys.map(key => `'${key}'`).join('\n | ')};\n`
   );
 }
 

--- a/src/blocks/PagePartialBlock/PagePartialBlock.astro
+++ b/src/blocks/PagePartialBlock/PagePartialBlock.astro
@@ -2,8 +2,7 @@
 import type { PagePartialBlockFragment } from '@lib/datocms/types';
 import GroupingBlock from '@blocks/GroupingBlock/GroupingBlock.astro';
 import type { GroupingBlockFragment } from '@lib/datocms/types';
-import { getEntry } from 'astro:content';
-import { getLocale } from '@lib/i18n';
+import { getEntry } from '@lib/content';
 
 export interface Props {
   block: PagePartialBlockFragment
@@ -13,7 +12,7 @@ const { block } = Astro.props;
 // TODO: only allow one page partial per block
 const pagePartials = await Promise.all(
   block.items.map(async (item) => {
-    const pagePartial = await getEntry('PagePartials', `${getLocale()}/${item.id}`);
+    const pagePartial = await getEntry('PagePartials', item.id);
     return pagePartial?.data;
   })
 ).then(items => items.filter(pagePartial => pagePartial !== undefined && pagePartial !== null));

--- a/src/blocks/PagePartialBlock/PagePartialBlock.astro
+++ b/src/blocks/PagePartialBlock/PagePartialBlock.astro
@@ -2,18 +2,27 @@
 import type { PagePartialBlockFragment } from '@lib/datocms/types';
 import GroupingBlock from '@blocks/GroupingBlock/GroupingBlock.astro';
 import type { GroupingBlockFragment } from '@lib/datocms/types';
+import { getEntry } from 'astro:content';
+import { getLocale } from '@lib/i18n';
 
 export interface Props {
   block: PagePartialBlockFragment
 }
 const { block } = Astro.props;
 
+// TODO: only allow one page partial per block
+const pagePartials = await Promise.all(
+  block.items.map(async (item) => {
+    const pagePartial = await getEntry('PagePartials', `${getLocale()}/${item.id}`);
+    return pagePartial?.data;
+  })
+).then(items => items.filter(pagePartial => pagePartial !== undefined && pagePartial !== null));
 ---
 {/* Temporary solution to prevent breaking changes for existing Page Partial Blocks */}
 <GroupingBlock block={{
   ...block,
   __typename: 'GroupingBlockRecord',
-  items: block.items.map(item => ({
+  items: pagePartials.map(item => ({
     title: item.title,
     blocks: item.blocks as GroupingBlockFragment['items'][number]['blocks'],
     __typename: 'GroupingItemRecord'

--- a/src/blocks/PagePartialBlock/PagePartialBlock.fragment.graphql
+++ b/src/blocks/PagePartialBlock/PagePartialBlock.fragment.graphql
@@ -1,43 +1,7 @@
-#import '@blocks/ActionBlock/ActionBlock.fragment.graphql'
-#import '@blocks/GroupingBlock/GroupingBlock.fragment.graphql'
-#import '@blocks/ImageBlock/ImageBlock.fragment.graphql'
-#import '@blocks/TableBlock/TableBlock.fragment.graphql'
-#import '@blocks/TextBlock/TextBlock.fragment.graphql'
-#import '@blocks/TextImageBlock/TextImageBlock.fragment.graphql'
-#import '@blocks/VideoBlock/VideoBlock.fragment.graphql'
-#import '@blocks/VideoEmbedBlock/VideoEmbedBlock.fragment.graphql'
-
 fragment PagePartialBlock on PagePartialBlockRecord {
   id
   items {
-    title
-    blocks {
-      __typename
-      ... on ActionBlockRecord {
-        ...ActionBlock
-      }
-      ... on GroupingBlockRecord {
-        ...GroupingBlock
-      }
-      ... on ImageBlockRecord {
-        ...ImageBlock
-      }
-      ... on TableBlockRecord {
-        ...TableBlock
-      }
-      ... on TextBlockRecord {
-        ...TextBlock
-      }
-      ... on TextImageBlockRecord {
-        ...TextImageBlock
-      }
-      ... on VideoBlockRecord {
-        ...VideoBlock
-      }
-      ... on VideoEmbedBlockRecord {
-        ...VideoEmbedBlock
-      }
-    }
+    id
   }
   layout
 }

--- a/src/blocks/PagePartialBlock/PagePartialBlock.test.ts
+++ b/src/blocks/PagePartialBlock/PagePartialBlock.test.ts
@@ -12,7 +12,7 @@ const layouts = [
   'tabs',
 ] as const;
 
-vi.mock('astro:content', () => ({
+vi.mock('../../lib/content', () => ({
   // fetch content from grouping block tests via mocked getEntry
   getEntry: (_: string, id: string, __: string) => {
     const index = Number(id.split('index-').pop()) || 0;

--- a/src/blocks/PagePartialBlock/PagePartialBlock.test.ts
+++ b/src/blocks/PagePartialBlock/PagePartialBlock.test.ts
@@ -1,5 +1,5 @@
 import { renderToFragment } from '@lib/renderer';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import PagePartialBlock, { type Props as PagePartialBlockProps } from './PagePartialBlock.astro';
 import GroupingBlock, { type Props as GroupingBlockProps } from '../GroupingBlock/GroupingBlock.astro';
 import { items } from '../GroupingBlock/GroupingBlock.test';
@@ -10,7 +10,18 @@ const layouts = [
   'accordion-closed',
   'accordion-open',
   'tabs',
-];
+] as const;
+
+vi.mock('astro:content', () => ({
+  // fetch content from grouping block tests via mocked getEntry
+  getEntry: (_: string, id: string, __: string) => {
+    const index = Number(id.split('index-').pop()) || 0;
+    return { 
+      id,
+      data: items[index],
+    };
+  },
+}));
 
 describe('PagePartialBlock', () => {
   layouts.forEach((layout) => {
@@ -20,8 +31,8 @@ describe('PagePartialBlock', () => {
           block: {
             __typename: 'PagePartialBlockRecord',
             id: 'ay-D0Z1ZTqWVszeV9ZqfJA',
+            items: items.map((_, i) => ({ id: `index-${i}` })),
             layout,
-            items: items.map(({ __typename, ...item }) => item), // Remove __typename since it is not part of the PagePartialBlock definition
           }
         }
       });

--- a/src/components/StructuredData/StructuredData.astro
+++ b/src/components/StructuredData/StructuredData.astro
@@ -1,7 +1,8 @@
 ---
+import { isLocale, defaultLocale } from '@lib/i18n';
 import { getSearchPathname, getOpenSearchName, queryParamName } from '@lib/search';
 
-const { locale } = Astro.params;
+const locale = isLocale(Astro.params.locale) ? Astro.params.locale : defaultLocale;
 
 const url = new URL(getSearchPathname(locale), Astro.site);
 

--- a/src/content/PagePartials/CollectionEntry.query.graphql
+++ b/src/content/PagePartials/CollectionEntry.query.graphql
@@ -1,0 +1,43 @@
+#import '@blocks/ActionBlock/ActionBlock.fragment.graphql'
+#import '@blocks/GroupingBlock/GroupingBlock.fragment.graphql'
+#import '@blocks/ImageBlock/ImageBlock.fragment.graphql'
+#import '@blocks/TableBlock/TableBlock.fragment.graphql'
+#import '@blocks/TextBlock/TextBlock.fragment.graphql'
+#import '@blocks/TextImageBlock/TextImageBlock.fragment.graphql'
+#import '@blocks/VideoBlock/VideoBlock.fragment.graphql'
+#import '@blocks/VideoEmbedBlock/VideoEmbedBlock.fragment.graphql'
+
+query PagePartialCollectionEntry($locale: SiteLocale!, $id: ItemId!) {
+  entry: pagePartial(locale: $locale, filter: { id: { eq: $id } }) {
+    __typename
+    id
+    title
+    blocks {
+      __typename
+      ... on ActionBlockRecord {
+        ...ActionBlock
+      }
+      ... on GroupingBlockRecord {
+        ...GroupingBlock
+      }
+      ... on ImageBlockRecord {
+        ...ImageBlock
+      }
+      ... on TableBlockRecord {
+        ...TableBlock
+      }
+      ... on TextBlockRecord {
+        ...TextBlock
+      }
+      ... on TextImageBlockRecord {
+        ...TextImageBlock
+      }
+      ... on VideoBlockRecord {
+        ...VideoBlock
+      }
+      ... on VideoEmbedBlockRecord {
+        ...VideoEmbedBlock
+      }
+    }
+  }
+}

--- a/src/content/PagePartials/index.ts
+++ b/src/content/PagePartials/index.ts
@@ -5,6 +5,7 @@ import {
   type SiteLocale
 } from '@lib/datocms/types';
 import { datocmsCollection, datocmsRequest } from '@lib/datocms';
+import { combine } from '@lib/content';
 
 export type PagePartialCollectionEntry = PagePartialCollectionEntryQuery['entry'] & {
   recordId: string,
@@ -22,7 +23,7 @@ const loadEntry = async (id: string, locale?: SiteLocale | null) => {
   return {
     ...entry,
     recordId: entry.id,
-    id: `${locale}/${entry.id}`,
+    id: combine({ id: entry.id, locale }),
     locale,
   } satisfies PagePartialCollectionEntry;
 };

--- a/src/content/PagePartials/index.ts
+++ b/src/content/PagePartials/index.ts
@@ -1,0 +1,75 @@
+import { defineCollection, z } from 'astro:content';
+import {
+  PagePartialCollectionEntry as query,
+  type PagePartialCollectionEntryQuery,
+  type SiteLocale
+} from '@lib/datocms/types';
+import { datocmsCollection, datocmsRequest } from '@lib/datocms';
+
+export type PagePartialCollectionEntry = PagePartialCollectionEntryQuery['entry'] & {
+  recordId: string,
+  id: string,
+  locale: SiteLocale,
+};
+
+const name = 'PagePartials' as const;
+
+const loadEntry = async (id: string, locale?: SiteLocale | null) => {
+  if (!locale) {
+    return;
+  }
+  const { entry } = await datocmsRequest<PagePartialCollectionEntryQuery>({ query, variables: { id, locale } });
+  return {
+    ...entry,
+    recordId: entry.id,
+    id: `${locale}/${entry.id}`,
+    locale,
+  } satisfies PagePartialCollectionEntry;
+};
+
+/** 
+ * Loads all entries from the collection, mapping them to their respective locales.
+ * 
+ * @returns A promise that resolves to an array of PagePartialCollectionEntry objects.
+ **/
+const loadCollection = async () => {
+  const items = (await datocmsCollection<{ 
+    id: string, 
+    _allBlocksLocales: { locale: SiteLocale }[] 
+  }>({
+    collection: name,
+    fragment: /* graphql */`
+      id
+      # We want all locales for each entry. Since the blocks are localized, 
+      # we can fetch the locales via _allBlocksLocales
+      _allBlocksLocales {
+        locale
+      }
+    `,
+  }))
+    // Flatten the array of entries to get an array of { id, locale } pairs.
+    .flatMap(({ id, _allBlocksLocales }) => _allBlocksLocales
+      .map(({ locale }) => ({ id, locale })) 
+    );
+
+  // For each id/locale pair, load the entry and return it.
+  // Note that this might be slow if there are many entries, as it makes a
+  // separate request for each entry.
+  return await Promise.all(items.map(({ id, locale }) => loadEntry(id, locale)))
+    .then(entries => entries.filter( entry => entry !== undefined));
+};
+
+const collection = defineCollection({
+  loader: loadCollection,
+  schema: z.custom<PagePartialCollectionEntry>(),
+});
+
+export default {
+  [name]: {
+    name,
+    collection,
+    loadCollection,
+    loadEntry,
+    query,
+  }
+};

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,18 @@
+// Astro expects a content/config.ts file, therefore we export the collections here.
+import PagePartialCollection from './PagePartials';
+
+export const collectionMap = {
+  // Add your collections here
+  ...PagePartialCollection,
+} as const;
+
+// Astro needs a value for collections that is an object whose keys are collection names
+// and whose values are the output of the `defineCollection function`.
+// In order to have live data and other niceties, we moved that output to a key called `collection`.
+// Therefore we have to extract the `collection` property from each entry in `collectionMap`.
+export const collections = Object.entries(collectionMap).reduce<
+  Record<string, typeof collectionMap[keyof typeof collectionMap]['collection']>
+>((acc, [key, { collection }]) => {
+  acc[key] = collection;
+  return acc;
+}, {});

--- a/src/lib/content/index.test.ts
+++ b/src/lib/content/index.test.ts
@@ -41,6 +41,11 @@ vi.mock('astro:content', async (original) => {
   };
 });
 
+vi.mock('astro:env/server', () => ({
+  HEAD_START_PREVIEW: false,
+  PUBLIC_IS_PRODUCTION: true,
+}));
+
 vi.mock('../i18n/index.ts', async (original) => {
   const actual = original();
   return {

--- a/src/lib/content/index.test.ts
+++ b/src/lib/content/index.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test, vi } from 'vitest';
+import { getCollection, getEntry, combine, split } from './index';
+import { getLocale } from '@lib/i18n';
+
+const locales = ['en', 'nl'] as const;
+const collections = {
+  'LocalizedItems': [
+    { id: `${locales[0]}/a`, data: { locale: locales[0], title: 'First Item' } },
+    { id: `${locales[0]}/b`, data: { locale: locales[0], title: 'Second Item' } },
+    { id: `${locales[0]}/c`, data: { locale: locales[0], title: 'Third Item' } },
+    { id: `${locales[1]}/a`, data: { locale: locales[1], title: 'Eerste onderdeel' } },
+    { id: `${locales[1]}/b`, data: { locale: locales[1], title: 'Tweede onderdeel' } },
+    { id: `${locales[1]}/c`, data: { locale: locales[1], title: 'Derde onderdeel' } },
+  ],
+  'NonLocalizedItems': [
+    { id: 'a', data: { title: 'First Item' } },
+    { id: 'b', data: { title: 'Second Item' } },
+    { id: 'c', data: { title: 'Third Item' } },
+  ]
+} as const;
+  
+// Mocking the Astro content module to simulate collections,
+vi.mock('astro:content', async (original) => {
+  const actual = await original();
+  return {
+    ...actual || {},
+    // getAstroCollection
+    getCollection: (
+      collection: keyof typeof collections, 
+      filter: (entry: unknown) => unknown
+    ) => {
+      return filter
+        ? collections[collection].filter(filter)
+        : collections[collection];
+    },
+    // getAstroCollectionEntry
+    getEntry: (collection: keyof typeof collections, id: string) => {
+      const entry = collections[collection].find(e => e.id === id);
+      return entry ? { ...entry, data: { ...entry.data } } : undefined;
+    },
+  };
+});
+
+vi.mock('../i18n/index.ts', async (original) => {
+  const actual = original();
+  return {
+    ...actual || {},
+    getLocale: () => locales[1],
+    isLocale: (l: string) => (locales as readonly string[]).includes(l),
+  };
+});
+
+describe('getCollection', () => {
+  test('filters by locale by default', async () => {
+    const collection = 'LocalizedItems';
+    const entries = await getCollection(collection as 'PagePartials');
+    const locale = getLocale();
+    expect(entries).toHaveLength(3);
+    expect(
+      entries.map(({ data: { locale } }) => ({ locale }))
+    ).toEqual([
+      { locale },
+      { locale },
+      { locale },
+    ]);
+  });
+  test('does not filter if entries do not have a locale', async () => {
+    const collection = 'NonLocalizedItems';
+    const entries = await getCollection(collection as 'PagePartials');
+    expect(entries).toHaveLength(3);
+    expect(entries).toEqual(collections[collection]);
+  });
+  test('does not filter localized entries when locale is set to null', async () => {
+    const collection = 'LocalizedItems';
+    const entries = await getCollection(collection as 'PagePartials', undefined, null);
+    expect(entries).toHaveLength(6);
+  });
+});
+
+describe('getEntry', () => {
+  test('filters by locale by default', async () => {
+    const collection = 'LocalizedItems';
+    const id = 'a';
+    const entry = await getEntry(collection as 'PagePartials', id);
+    const locale = getLocale();
+    expect(entry).toBeDefined();
+    expect(entry?.id).toBe(`${locale}/${id}`);
+    expect(entry?.data.locale).toBe(locale);
+  });
+  test('does not filter if entries do not have a locale', async () => {
+    const collection = 'NonLocalizedItems';
+    const id = 'a';
+    const entry = await getEntry(collection as 'PagePartials', id);
+    expect(entry).toBeDefined();
+  });
+});
+
+describe('combine', () => {
+  test('appends a separator and locale to a given id', () => {
+    locales.forEach(locale => {
+      const result = combine({ id: 'a/b/c', locale });
+      expect(result).toBe(`${locale}/a/b/c`);
+    });
+  });
+  test('does not alter id when locale is falsy', () => {
+    const locales = [undefined, null];
+    locales.forEach(locale => {
+      const result = combine({ id: 'a/b/c', locale });
+      expect(result).toBe('a/b/c');
+    });
+  });
+});
+
+describe('split', () => {
+  test('extracts locale from id with appended locale', () => {
+    const result = split('nl/a/b/c');
+    expect(result).toStrictEqual({ id: 'a/b/c', locale: 'nl' });
+  });
+  test('returns undefined when no locale is present', () => {
+    const result = split('a/b/c');
+    expect(result).toStrictEqual({ id: 'a/b/c', locale: null });
+  });
+  test('extracts locale added with combine', () => {
+    const id = 'a/b/c';
+    const locale = 'en';
+    const result = split(combine({ id, locale }));
+    expect(result).toStrictEqual({ id: 'a/b/c', locale });
+  });
+  test('extracts locale added with combine', () => {
+    const id = 'a/b/c';
+    const locale = 'en';
+    const result = split(combine({ id, locale } ));
+    expect(result).toStrictEqual({ id: 'a/b/c', locale });
+  });
+});

--- a/src/lib/content/index.ts
+++ b/src/lib/content/index.ts
@@ -1,0 +1,77 @@
+import { getCollection as getAstroCollection, getEntry as getAstroCollectionEntry } from 'astro:content';
+import { getLocale, isLocale } from '@lib/i18n';
+import { SiteLocale } from '@lib/datocms/types';
+import { collectionMap } from '@content/config';
+
+export type CollectionName = keyof typeof collectionMap;
+/**
+ * CollectionEntry is a type that represents a single entry in a collection.
+ */ 
+export type CollectionEntry<Key extends CollectionName> = NormalizedEntry<
+  Awaited<ReturnType<typeof collectionMap[Key]['loadCollection']>>[number]
+>;
+
+/**
+ * Fetches entries from a collection.
+ *
+ * @param collection - The key of the collection to fetch entries from
+ * @param filter - Optional SiteLocale or function to filter the collection entries
+ * @returns A promise that resolves to an array of normalized collection entries
+ */
+export async function getCollection<Key extends CollectionName>(
+  collection: Key,
+  filter?: ((entry: CollectionEntry<Key>) => boolean),
+  locale: SiteLocale | null = getLocale(),
+): Promise<CollectionEntry<Key>[]> {
+  if (!filter && !locale) {
+    return getAstroCollection(collection);
+  }
+  
+  return getAstroCollection(collection, (entry: CollectionEntry<Key>) => {
+    const entryLocale = split(entry.id).locale;
+    return [
+      // Check if the entry's locale is set and matches the requested locale
+      !locale || !entryLocale || entryLocale === locale,
+      // If a filter function is provided, apply it to the entry
+      !filter || (typeof filter === 'function' && filter(entry)),
+    ].every(Boolean);
+  });
+}
+
+/**
+ * Fetches a single entry from a collection by its slug.
+ *
+ * @param collection - The key of the collection to fetch the entry from
+ * @param id - The id of the entry to fetch
+ * @param locale - Optional SiteLocale to find the localized entry.
+ * @returns A promise that resolves to the requested collection entry or undefined if not found
+ */
+export async function getEntry<Key extends CollectionName>(
+  collection: Key,
+  id: string,
+  locale: SiteLocale | null = getLocale(),
+) {
+  const entry = await getAstroCollectionEntry(collection, combine({ id, locale }));
+  
+  // If the entry is not found, try to fetch it without locale
+  return (locale)
+    ? entry || await getAstroCollectionEntry(collection, id)
+    : entry;
+}
+
+export function combine({ id, locale }: { id: string, locale?: SiteLocale | null }) {
+  return locale ? `${locale}/${id}` : id;
+}
+
+export function split(value: string) {
+  let locale: SiteLocale | null = null;
+  let id = value;
+  const [first, ...rest] = value.split('/');
+  
+  if (isLocale(first)) {
+    locale = first;
+    id = rest.join('/');
+  }
+  
+  return { id, locale };
+}

--- a/src/lib/content/index.ts
+++ b/src/lib/content/index.ts
@@ -1,4 +1,5 @@
 import { getCollection as getAstroCollection, getEntry as getAstroCollectionEntry } from 'astro:content';
+import { HEAD_START_PREVIEW, PUBLIC_IS_PRODUCTION } from 'astro:env/server';
 import { getLocale, isLocale } from '@lib/i18n';
 import { SiteLocale } from '@lib/datocms/types';
 import { collectionMap } from '@content/config';
@@ -11,6 +12,7 @@ export type CollectionEntry<Key extends CollectionName> = NormalizedEntry<
   Awaited<ReturnType<typeof collectionMap[Key]['loadCollection']>>[number]
 >;
 
+const useLiveData = !PUBLIC_IS_PRODUCTION || HEAD_START_PREVIEW;
 /**
  * Fetches entries from a collection.
  *
@@ -50,13 +52,40 @@ export async function getEntry<Key extends CollectionName>(
   collection: Key,
   id: string,
   locale: SiteLocale | null = getLocale(),
-) {
-  const entry = await getAstroCollectionEntry(collection, combine({ id, locale }));
+): Promise<CollectionEntry<Key> | undefined> {
+  let entry: CollectionEntry<Key> | undefined = undefined;
   
-  // If the entry is not found, try to fetch it without locale
+  if (useLiveData) {
+    const liveEntry = await collectionMap[collection].loadEntry(id, locale);
+    if (liveEntry) {
+      entry = normalizeEntry(liveEntry, collection);
+    }
+  } else {
+    entry = await getAstroCollectionEntry(collection, combine({ id, locale }));
+  }
+  
   return (locale)
-    ? entry || await getAstroCollectionEntry(collection, id)
+    ? entry || await getEntry(collection, id, null) // Retry once to the entry without locale if not found
     : entry;
+}
+
+type Entry = { id: string; };
+type NormalizedEntry<T extends Entry> = {
+  id: string;
+  collection: string;
+  data: T;
+};
+
+/**
+ * Wrap an entry from loadCollection in a format that corresponds to Astro's 
+ * getCollection return type.
+ */
+function normalizeEntry<T extends Entry>(entry: T, collection: string): NormalizedEntry<T> {
+  return {
+    id: entry.id,
+    collection: collection,
+    data: entry as T,
+  };
 }
 
 export function combine({ id, locale }: { id: string, locale?: SiteLocale | null }) {

--- a/src/lib/datocms/index.ts
+++ b/src/lib/datocms/index.ts
@@ -1,6 +1,6 @@
 import { Kind, parse, type DocumentNode, type FragmentDefinitionNode } from 'graphql';
 import { print } from 'graphql/language/printer';
-import type { SiteLocale } from '@lib/i18n/types';
+import type { SiteLocale } from '@lib/datocms/types';
 import { titleSuffix } from '@lib/seo';
 import { datocmsBuildTriggerId, datocmsEnvironment } from '@root/datocms-environment';
 import { output } from '@root/config/output';

--- a/src/lib/datocms/tests/datocmsSearch.test.ts
+++ b/src/lib/datocms/tests/datocmsSearch.test.ts
@@ -10,7 +10,7 @@ import {
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { datocmsSearch } from '@lib/datocms';
-import type { SiteLocale } from '@lib/datocms/types.ts';
+import type { SiteLocale } from '@lib/datocms/types';
 
 vi.mock('../../../../datocms-environment', () => ({
   datocmsBuildTriggerId: 'mock-build-trigger-id',

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -1,5 +1,6 @@
 import rosetta from 'rosetta';
-import type { SiteLocale, TranslationKey } from '@lib/i18n/types';
+import type { TranslationKey } from '@lib/i18n/types';
+import { type SiteLocale } from '@lib/datocms/types';
 import messages from '@lib/i18n/messages.json';
 import { locales as siteLocales } from '@lib/site.json';
 
@@ -10,7 +11,7 @@ export const cookieName = 'HEAD_START_LOCALE';
 const i18n = rosetta(messages);
 
 if (typeof document !== 'undefined') {
-  setLocale(document.documentElement.lang as SiteLocale);
+  setLocale(document.documentElement.lang);
 } else {
   i18n.locale(defaultLocale);
 }
@@ -26,7 +27,7 @@ export const t: T = (key: TranslationKey, params?: any[] | Record<string, any>, 
 };
 
 export function getLocale() {
-  return i18n.locale();
+  return i18n.locale() as SiteLocale;
 }
 
 export function isLocale<T extends typeof locales>(locale: unknown): locale is T[number] {

--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -1,12 +1,13 @@
+import type { SiteLocale } from '@lib/datocms/types';
 import { getLocale } from '@lib/i18n';
 import { globalSeo } from '@lib/site.json';
 
 export const queryParamName = 'query';
 export const minQueryLength = 3;
 export const hasValidQuery = (query: string) => (query.length >= minQueryLength);
-export const getSearchPathname = (locale = getLocale()) => `/${ locale }/search/`;
-export const getOpenSearchName = (locale = getLocale()) => `${globalSeo[locale as keyof typeof globalSeo]?.siteName} (${ locale })`;
-export const getOpenSearchPathname = (locale: string) => `${ getSearchPathname(locale) }opensearch.xml`;
+export const getSearchPathname = (locale: SiteLocale = getLocale()) => `/${ locale }/search/`;
+export const getOpenSearchName = (locale: SiteLocale = getLocale()) => `${globalSeo[locale as keyof typeof globalSeo]?.siteName} (${ locale })`;
+export const getOpenSearchPathname = (locale: SiteLocale) => `${ getSearchPathname(locale) }opensearch.xml`;
 
 // https://www.datocms.com/docs/site-search/excluding-text
 export const datocmsNoIndex = { 'data-datocms-noindex': '' };

--- a/src/lib/seo/index.ts
+++ b/src/lib/seo/index.ts
@@ -1,6 +1,5 @@
-import type { Tag } from '@lib/datocms/types';
+import type { Tag, SiteLocale } from '@lib/datocms/types';
 import { getLocale } from '@lib/i18n';
-import type { SiteLocale } from '@lib/i18n/types';
 import { globalSeo } from '@lib/site.json';
 import aiRobotsTxt from './ai.robots.txt?raw';
 

--- a/src/middleware/i18n.ts
+++ b/src/middleware/i18n.ts
@@ -1,6 +1,5 @@
 import { defineMiddleware } from 'astro:middleware';
-import { defaultLocale, locales, setLocale } from '@lib/i18n';
-import type { SiteLocale } from '@lib/i18n/types';
+import { defaultLocale, isLocale, setLocale } from '@lib/i18n';
 
 /**
  * i18n middleware:
@@ -11,12 +10,12 @@ export const i18n = defineMiddleware(async ({ params, request }, next) => {
     // if the locale param is unavailable, it didn't match a [locale]/* route
     // so we attempt to extract the locale from the URL and fallback to the default locale
     const pathLocale = new URL(request.url).pathname.split('/')[1];
-    const locale = locales.includes(pathLocale as SiteLocale)
+    const locale = isLocale(pathLocale)
       ? pathLocale
       : defaultLocale;
     Object.assign(params, { locale });
   }
-  setLocale(params.locale as SiteLocale);
+  setLocale(params.locale);
 
   const response = await next();
   return response;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,6 +1,5 @@
 ---
-import type { SiteLocale } from '@lib/i18n/types';
-import type { NotFoundPageQuery } from '@lib/datocms/types';
+import type { NotFoundPageQuery, SiteLocale } from '@lib/datocms/types';
 import { datocmsRequest } from '@lib/datocms';
 import { noIndexTag, titleTag } from '@lib/seo';
 import Layout from '@layouts/Default.astro';

--- a/src/pages/[locale]/search/index.astro
+++ b/src/pages/[locale]/search/index.astro
@@ -1,8 +1,8 @@
 ---
 import { locales, t } from '@lib/i18n';
-import type { SiteLocale } from '@lib/i18n/types';
 import { noIndexTag, siteName, titleTag } from '@lib/seo';
 import { datocmsSearch } from '@lib/datocms';
+import type { SiteLocale } from '@lib/datocms/types';
 import { hasValidQuery, getSearchPathname, queryParamName } from '@lib/search';
 import Layout from '@layouts/Default.astro';
 import SearchForm from '@components/SearchForm.astro';

--- a/src/pages/[locale]/search/opensearch.xml.ts
+++ b/src/pages/[locale]/search/opensearch.xml.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { locales } from '@lib/i18n';
+import { defaultLocale, isLocale, locales } from '@lib/i18n';
 import { datocmsRequest } from '@lib/datocms';
 import type { OpenSearchXmlQuery } from '@lib/datocms/types';
 import { getSearchPathname, getOpenSearchName, queryParamName } from '@lib/search';
@@ -33,7 +33,7 @@ const openSearchXml = (
 `.trim();
 
 export const GET: APIRoute = async ({ params, site }) => {
-  const locale = params.locale!;
+  const locale = isLocale(params.locale) ? params.locale : defaultLocale;
   const data = await datocmsRequest<OpenSearchXmlQuery>({ query, variables: { locale } });
   const { favicon, globalSeo } = data.site;
   const searchPageUrl = `${ site!.origin }${ getSearchPathname(locale) }`;

--- a/src/pages/[locale]/search/results.partial.astro
+++ b/src/pages/[locale]/search/results.partial.astro
@@ -1,7 +1,7 @@
 ---
 import { hasValidQuery, queryParamName } from '@lib/search';
 import { datocmsSearch } from '@lib/datocms';
-import type { SiteLocale } from '@lib/i18n/types';
+import type { SiteLocale } from '@lib/datocms/types';
 import SearchResult from '@components/SearchResult.astro';
 
 export const partial = true;

--- a/src/pages/api/search/index.ts
+++ b/src/pages/api/search/index.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { locales } from '@lib/i18n';
-import type { SiteLocale } from '@lib/i18n/types';
+import type { SiteLocale } from '@lib/datocms/types';
 import { datocmsSearch } from '@lib/datocms';
 import { minQueryLength, queryParamName } from '@lib/search';
 

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import parser from 'accept-language-parser';
 import { cookieName, defaultLocale, locales } from '@lib/i18n';
-import type { SiteLocale } from '@lib/i18n/types';
+import type { SiteLocale } from '@lib/datocms/types';
 
 export const prerender = false;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
       "@assets/*": ["src/assets/*"],
       "@blocks/*": ["src/blocks/*"],
       "@components/*": ["src/components/*"],
+      "@content/*": ["src/content/*"],
       "@layouts/*": ["src/layouts/*"],
       "@lib/*": ["src/lib/*"],
       "@middleware/*": ["src/middleware/*"],


### PR DESCRIPTION
# Changes

- Adds initial implementation of content collections
- Uses content collections for page partials to reduce query complexity
- Handles localization within content collections
- Bypasses astro collections in development and preview
- Cleans up SiteLocale by using as const instead of enum for generated DatoCMS types

# Associated issue

Partially resolves #166

# How to test

1. Open preview link
2. Navigate to Page Partial Demo
4. Verify that Page Partials show up

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
