### PR TITLE
feature: Search Form Block

### DIFF
--- a/config/datocms/migrations/1779356356_devSandbox2105.ts
+++ b/config/datocms/migrations/1779356356_devSandbox2105.ts
@@ -1,0 +1,160 @@
+import { Client } from '@datocms/cli/lib/cma-client-node';
+
+export default async function (client: Client) {
+  console.log('Create new models/block models');
+
+  console.log(
+    'Create block model "\uD83D\uDD0D Search form block" (`search_form_block`)',
+  );
+  await client.itemTypes.create(
+    {
+      id: 'QzOde8F5Qy6r7HPIazVIeQ',
+      name: '\uD83D\uDD0D Search form block',
+      api_key: 'search_form_block',
+      modular_block: true,
+      draft_saving_active: false,
+      hint: '',
+      inverse_relationships_enabled: false,
+    },
+    {
+      skip_menu_item_creation: true,
+      schema_menu_item_id: 'LkFE7qE2QumOj8v2267xHA',
+    },
+  );
+
+  console.log('Creating new fields/fieldsets');
+
+  console.log(
+    'Create Single-line string field "Title" (`title`) in block model "\uD83D\uDD0D Search form block" (`search_form_block`)',
+  );
+  await client.fields.create('QzOde8F5Qy6r7HPIazVIeQ', {
+    id: 'JdRxITLwT9GIuvLpQvSWFQ',
+    label: 'Title',
+    field_type: 'string',
+    api_key: 'title',
+    appearance: {
+      addons: [],
+      editor: 'single_line',
+      parameters: { heading: false, placeholder: null },
+    },
+    default_value: null,
+  });
+
+  console.log(
+    'Create Single-line string field "Query" (`query`) in block model "\uD83D\uDD0D Search form block" (`search_form_block`)',
+  );
+  await client.fields.create('QzOde8F5Qy6r7HPIazVIeQ', {
+    id: 'SZLwkYXuTD21tWzzinv8Fg',
+    label: 'Query',
+    field_type: 'string',
+    api_key: 'query',
+    appearance: {
+      addons: [],
+      editor: 'single_line',
+      parameters: { heading: false, placeholder: null },
+    },
+    default_value: null,
+  });
+
+  console.log('Update existing fields/fieldsets');
+
+  console.log(
+    'Update Modular Content (Multiple blocks) field "Body" (`blocks`) in model "\uD83E\uDDE9 Page Partial" (`page_partial`)',
+  );
+  await client.fields.update('SKLmdv71Rge0rKhJzOFQWQ', {
+    validators: {
+      rich_text_blocks: {
+        item_types: [
+          'BRbU6VwTRgmG5SbwUs0rBg',
+          'F60ZY1wFSW2qbvh99poj3g',
+          'PAk40zGjQJCcDXXPgygUrA',
+          'QYfZyBzIRWKxA1MinIR0aQ',
+          'QzOde8F5Qy6r7HPIazVIeQ',
+          'TBuD6qQOSDy6i9dM3T_XEA',
+          'Tv6MHewBS4evujN0EuSrwQ',
+          'ZdBokLsWRgKKjHrKeJzdpw',
+          'gezG9nO7SfaiWcWnp-HNqw',
+          '0SxYNS2CR1it_5LHYWuEQg',
+        ],
+      },
+    },
+  });
+
+  console.log(
+    'Update Modular Content (Multiple blocks) field "Body" (`body_blocks`) in model "\uD83D\uDCD1 Page" (`page`)',
+  );
+  await client.fields.update('Q-z1nyMsQtC8Sr6w6J2oGw', {
+    validators: {
+      rich_text_blocks: {
+        item_types: [
+          'BRbU6VwTRgmG5SbwUs0rBg',
+          'F60ZY1wFSW2qbvh99poj3g',
+          'PAk40zGjQJCcDXXPgygUrA',
+          'QYfZyBzIRWKxA1MinIR0aQ',
+          'QzOde8F5Qy6r7HPIazVIeQ',
+          'TBuD6qQOSDy6i9dM3T_XEA',
+          'Tv6MHewBS4evujN0EuSrwQ',
+          'VZvVfu52RZK81WG0Dxp-FQ',
+          'V80liDVtRC-UYgd3Sm-dXg',
+          'ZdBokLsWRgKKjHrKeJzdpw',
+          'gezG9nO7SfaiWcWnp-HNqw',
+          '0SxYNS2CR1it_5LHYWuEQg',
+        ],
+      },
+    },
+  });
+
+  console.log(
+    'Update Modular Content (Multiple blocks) field "Body" (`body_blocks`) in model "\uD83C\uDFE0 Home" (`home_page`)',
+  );
+  await client.fields.update('pUj2PObgTyC-8X4lvZLMBA', {
+    validators: {
+      rich_text_blocks: {
+        item_types: [
+          'BRbU6VwTRgmG5SbwUs0rBg',
+          'F60ZY1wFSW2qbvh99poj3g',
+          'PAk40zGjQJCcDXXPgygUrA',
+          'QYfZyBzIRWKxA1MinIR0aQ',
+          'QzOde8F5Qy6r7HPIazVIeQ',
+          'TBuD6qQOSDy6i9dM3T_XEA',
+          'VZvVfu52RZK81WG0Dxp-FQ',
+          'V80liDVtRC-UYgd3Sm-dXg',
+          'ZdBokLsWRgKKjHrKeJzdpw',
+          'gezG9nO7SfaiWcWnp-HNqw',
+          '0SxYNS2CR1it_5LHYWuEQg',
+        ],
+      },
+    },
+  });
+
+  console.log(
+    'Update Modular Content (Multiple blocks) field "Body" (`body_blocks`) in model "\uD83E\uDD37 Not found" (`not_found_page`)',
+  );
+  await client.fields.update('Zu006Xq0TMCAvV-vyQ_Iiw', {
+    validators: {
+      rich_text_blocks: {
+        item_types: [
+          'BRbU6VwTRgmG5SbwUs0rBg',
+          'F60ZY1wFSW2qbvh99poj3g',
+          'PAk40zGjQJCcDXXPgygUrA',
+          'QYfZyBzIRWKxA1MinIR0aQ',
+          'QzOde8F5Qy6r7HPIazVIeQ',
+          'VZvVfu52RZK81WG0Dxp-FQ',
+          'V80liDVtRC-UYgd3Sm-dXg',
+          'ZdBokLsWRgKKjHrKeJzdpw',
+          'gezG9nO7SfaiWcWnp-HNqw',
+          '0SxYNS2CR1it_5LHYWuEQg',
+        ],
+      },
+    },
+  });
+
+  console.log('Finalize models/block models');
+
+  console.log(
+    'Update block model "\uD83D\uDD0D Search form block" (`search_form_block`)',
+  );
+  await client.itemTypes.update('QzOde8F5Qy6r7HPIazVIeQ', {
+    presentation_title_field: { id: 'JdRxITLwT9GIuvLpQvSWFQ', type: 'field' },
+  });
+}

--- a/config/datocms/migrations/1779356356_searchFormBlock.ts
+++ b/config/datocms/migrations/1779356356_searchFormBlock.ts
@@ -48,6 +48,7 @@ export default async function (client: Client) {
     label: 'Query',
     field_type: 'string',
     api_key: 'query',
+    hint: 'Pre-fill priority for the search input: 1. CMS query (this field), 2. URL query parameter (?query=…), 3. last URL path segment, 4. empty.',
     appearance: {
       addons: [],
       editor: 'single_line',

--- a/datocms-environment.ts
+++ b/datocms-environment.ts
@@ -2,5 +2,5 @@
  * @see docs/getting-started.md on how to use this file
  * @see docs/decision-log/2023-10-24-datocms-env-file.md on why file is preferred over env vars
  */
-export const datocmsEnvironment = 'deploy-table-of-contents';
+export const datocmsEnvironment = 'test-search-form-block';
 export const datocmsBuildTriggerId = '34548';

--- a/datocms-environment.ts
+++ b/datocms-environment.ts
@@ -2,5 +2,5 @@
  * @see docs/getting-started.md on how to use this file
  * @see docs/decision-log/2023-10-24-datocms-env-file.md on why file is preferred over env vars
  */
-export const datocmsEnvironment = 'test-search-form-block';
+export const datocmsEnvironment = 'deploy-search-form';
 export const datocmsBuildTriggerId = '34548';

--- a/src/blocks/Blocks.d.ts
+++ b/src/blocks/Blocks.d.ts
@@ -3,6 +3,7 @@ import type {
   EmbedBlockFragment,
   ImageBlockFragment,
   PagePartialBlockFragment,
+  SearchFormBlockFragment,
   TableBlockFragment,
   TextBlockFragment,
   TextImageBlockFragment,
@@ -28,6 +29,7 @@ export type AnyBlock = Omit<
     | VideoEmbedBlockFragment
     | CounterBlockFragment
     | ListBlockFragment
+    | SearchFormBlockFragment
     | VariableBlockRecord
     | IconBlockFragment
   ), '__typename' // Allow for any __typename so that missing blocks can be reported on.

--- a/src/blocks/SearchFormBlock/README.md
+++ b/src/blocks/SearchFormBlock/README.md
@@ -1,0 +1,11 @@
+# Search Form Block
+
+**Content block with a pre-filled search form.**
+
+## Features
+
+- Semantic search form: `form[role="search"]`.
+- Semantic search input: `input[type="search"]`.
+- Input is prefilled with query defined in CMS (`block: { query: 'text' }`) if provided.
+- Input is prefilled with query from URL (`?query=text`) if otherwise provided.
+- Input is prefilled with path name from URL `/:locale/:path-name/` if no other value is available.

--- a/src/blocks/SearchFormBlock/README.md
+++ b/src/blocks/SearchFormBlock/README.md
@@ -6,6 +6,12 @@
 
 - Semantic search form: `form[role="search"]`.
 - Semantic search input: `input[type="search"]`.
-- Input is prefilled with query defined in CMS (`block: { query: 'text' }`) if provided.
-- Input is prefilled with query from URL (`?query=text`) if otherwise provided.
-- Input is prefilled with path name from URL `/:locale/:path-name/` if no other value is available.
+
+## Pre-fill behavior
+
+The search input is pre-filled automatically based on context. The first available value wins:
+
+1. **CMS query** — a query set directly on the block in the CMS (`block.query`).
+2. **URL query parameter** — `?query=my+search` in the page URL.
+3. **URL path segment** — the last path segment of the current URL (e.g. `/en/my-topic/` → `my topic`).
+4. **Empty** — the input starts blank if none of the above apply.

--- a/src/blocks/SearchFormBlock/SearchFormBlock.astro
+++ b/src/blocks/SearchFormBlock/SearchFormBlock.astro
@@ -1,0 +1,19 @@
+---
+// import type { SearchFormBlockFragment } from '@lib/datocms/types';
+import SearchForm from '@components/SearchForm/SearchForm.astro';
+
+type SearchFormBlockFragment = { // @todo: replace with actual fragment from DatoCMS
+  query: string;
+};
+
+export interface Props {
+  block: SearchFormBlockFragment;
+}
+const { block } = Astro.props as Props;
+---
+
+<search-form-block>
+  <SearchForm query={ block.query ?? '' } />
+</search-form-block>
+
+<script src="./SearchFormBlock.client.ts"></script>

--- a/src/blocks/SearchFormBlock/SearchFormBlock.astro
+++ b/src/blocks/SearchFormBlock/SearchFormBlock.astro
@@ -10,11 +10,7 @@ const { block } = Astro.props;
 
 <search-form-block>
   {block.title && <h2>{block.title}</h2>}
-  <SearchForm query={ block.query ?? '' } blockId={ block.id } />
+  <SearchForm query={block.query ?? ''} blockId={block.id} />
 </search-form-block>
 
 <script src="./SearchFormBlock.client.ts"></script>
-<script define:vars={{ block }}>
-  console.log('SearchFormBlock rendered', 'title', block.title); // For debugging purposes, to confirm the component is rendering
-  console.log('id', 'title', block.id); // For debugging purposes, to confirm the component is rendering
-</script>

--- a/src/blocks/SearchFormBlock/SearchFormBlock.astro
+++ b/src/blocks/SearchFormBlock/SearchFormBlock.astro
@@ -1,19 +1,20 @@
 ---
-// import type { SearchFormBlockFragment } from '@lib/datocms/types';
-import SearchForm from '@components/SearchForm/SearchForm.astro';
-
-type SearchFormBlockFragment = { // @todo: replace with actual fragment from DatoCMS
-  query: string;
-};
+import type { SearchFormBlockFragment } from '~/lib/datocms/types';
+import SearchForm from '~/components/SearchForm/SearchForm.astro';
 
 export interface Props {
   block: SearchFormBlockFragment;
 }
-const { block } = Astro.props as Props;
+const { block } = Astro.props;
 ---
 
 <search-form-block>
-  <SearchForm query={ block.query ?? '' } />
+  {block.title && <h2>{block.title}</h2>}
+  <SearchForm query={ block.query ?? '' } blockId={ block.id } />
 </search-form-block>
 
 <script src="./SearchFormBlock.client.ts"></script>
+<script define:vars={{ block }}>
+  console.log('SearchFormBlock rendered', 'title', block.title); // For debugging purposes, to confirm the component is rendering
+  console.log('id', 'title', block.id); // For debugging purposes, to confirm the component is rendering
+</script>

--- a/src/blocks/SearchFormBlock/SearchFormBlock.client.ts
+++ b/src/blocks/SearchFormBlock/SearchFormBlock.client.ts
@@ -1,0 +1,45 @@
+import { getLocale } from '@lib/i18n';
+import { queryParamName } from '@lib/search';
+
+class SearchFormBlock extends HTMLElement {
+  #input: HTMLInputElement;
+
+  constructor() {
+    super();
+    this.#input = this.querySelector('input[type="search"]') as HTMLInputElement;
+  }
+
+  #prefillInput() {
+    // if input has a server-side value, keep that value:
+    if (this.#input.value) {
+      return;
+    }
+  
+    // if URL has a query parameter, prefill the input with that value:
+    const urlParams = new URLSearchParams(window.location.search);
+    const query = urlParams.get(queryParamName);
+    if (query) {
+      this.#input.value = query;
+      return;
+    }
+
+    // otherwise, prefill with the prettified path name:
+    const { pathname } = window.location;
+    const locale = getLocale();
+    const strippedPathname = pathname.startsWith(`/${locale}/`)
+      ? pathname.slice(`/${locale}/`.length)
+      : pathname;
+    const prettyPathname = strippedPathname.replace(/[-/]/g, ' ');
+    this.#input.value = prettyPathname;
+  }
+
+  connectedCallback() {
+    if (!this.#input) {
+      console.error('SearchFormBlock: No input[type="search"] found');
+      return;
+    }
+    this.#prefillInput();
+  }
+}
+
+customElements.define('search-form-block', SearchFormBlock);

--- a/src/blocks/SearchFormBlock/SearchFormBlock.client.ts
+++ b/src/blocks/SearchFormBlock/SearchFormBlock.client.ts
@@ -1,5 +1,5 @@
-import { getLocale } from '@lib/i18n';
-import { queryParamName } from '@lib/search';
+import { getLocale } from '~/lib/i18n';
+import { queryParamName } from '~/lib/search';
 
 class SearchFormBlock extends HTMLElement {
   #input: HTMLInputElement;

--- a/src/blocks/SearchFormBlock/SearchFormBlock.client.ts
+++ b/src/blocks/SearchFormBlock/SearchFormBlock.client.ts
@@ -6,7 +6,9 @@ class SearchFormBlock extends HTMLElement {
 
   constructor() {
     super();
-    this.#input = this.querySelector('input[type="search"]') as HTMLInputElement;
+    this.#input = this.querySelector(
+      'input[type="search"]',
+    ) as HTMLInputElement;
   }
 
   #prefillInput() {
@@ -14,7 +16,7 @@ class SearchFormBlock extends HTMLElement {
     if (this.#input.value) {
       return;
     }
-  
+
     // if URL has a query parameter, prefill the input with that value:
     const urlParams = new URLSearchParams(window.location.search);
     const query = urlParams.get(queryParamName);

--- a/src/blocks/SearchFormBlock/SearchFormBlock.fragment.graphql
+++ b/src/blocks/SearchFormBlock/SearchFormBlock.fragment.graphql
@@ -1,0 +1,6 @@
+fragment SearchFormBlock on SearchFormBlockRecord {
+  __typename
+  id
+  title
+  query
+}

--- a/src/blocks/SearchFormBlock/SearchFormBlock.test.ts
+++ b/src/blocks/SearchFormBlock/SearchFormBlock.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('~/lib/i18n', () => ({
+  getLocale: () => 'en',
+  t: (key: string) => key,
+  locales: ['en', 'nl'],
+  defaultLocale: 'en',
+  isLocale: (locale: unknown) => ['en', 'nl'].includes(locale as string),
+  setLocale: vi.fn(),
+  cookieName: 'HEAD_START_LOCALE',
+}));
+
+vi.mock('~/lib/search', () => ({
+  queryParamName: 'query',
+  minQueryLength: 3,
+  hasValidQuery: (q: string) => q.length >= 3,
+  getSearchPathname: () => '/en/search/',
+}));
+
+import './SearchFormBlock.client';
+
+describe('SearchFormBlock client', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  function appendBlock(inputValue: string): HTMLInputElement {
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = `<search-form-block><input type="search" value="${inputValue}" /></search-form-block>`;
+    document.body.appendChild(wrapper.firstElementChild!);
+    return document.body.lastElementChild!.querySelector('input[type="search"]') as HTMLInputElement;
+  }
+
+  test('keeps DatoCMS content when input already has a value', () => {
+    vi.stubGlobal('location', { pathname: '/en/some-page', search: '?query=url-query' });
+    expect(appendBlock('dato query').value).toBe('dato query');
+  });
+
+  test('uses URL query param when there is no DatoCMS content', () => {
+    vi.stubGlobal('location', { pathname: '/en/some-page', search: '?query=url+query' });
+    expect(appendBlock('').value).toBe('url query');
+  });
+
+  test('uses prettified pathname when there is no content and no URL query', () => {
+    vi.stubGlobal('location', { pathname: '/en/some-page', search: '' });
+    expect(appendBlock('').value).toBe('some page');
+  });
+
+  describe('priority order: DatoCMS content > URL query param > URL path', () => {
+    test('DatoCMS content wins over URL query and path', () => {
+      vi.stubGlobal('location', { pathname: '/en/some-page', search: '?query=url-query' });
+      expect(appendBlock('dato query').value).toBe('dato query');
+    });
+
+    test('URL query wins over path when there is no DatoCMS content', () => {
+      vi.stubGlobal('location', { pathname: '/en/some-page', search: '?query=url-query' });
+      expect(appendBlock('').value).toBe('url-query');
+    });
+
+    test('path is used as last resort when there is no DatoCMS content and no URL query', () => {
+      vi.stubGlobal('location', { pathname: '/en/some-page', search: '' });
+      expect(appendBlock('').value).toBe('some page');
+    });
+  });
+});

--- a/src/blocks/blocksByTypename.ts
+++ b/src/blocks/blocksByTypename.ts
@@ -12,6 +12,7 @@ import TextImageBlock from './TextImageBlock/TextImageBlock.astro';
 import VariableBlock from './VariableBlock/VariableBlock.astro';
 import VideoBlock from './VideoBlock/VideoBlock.astro';
 import VideoEmbedBlock from './VideoEmbedBlock/VideoEmbedBlock.astro';
+import SearchFormBlock from './SearchFormBlock/SearchFormBlock.astro';
 
 export const blocksByTypename = {
   ActionBlockRecord: ActionBlock,
@@ -28,4 +29,5 @@ export const blocksByTypename = {
   VariableBlockRecord: VariableBlock,
   VideoBlockRecord: VideoBlock,
   VideoEmbedBlockRecord: VideoEmbedBlock,
+  SearchFormBlockRecord: SearchFormBlock,
 };

--- a/src/components/SearchForm/README.md
+++ b/src/components/SearchForm/README.md
@@ -1,0 +1,8 @@
+# Search Form
+
+**Semantic search form connected to the search page.**
+
+## Features
+
+- Semantic search form: `form[role="search"]`.
+- Semantic search input: `input[type="search"]`.

--- a/src/components/SearchForm/SearchForm.astro
+++ b/src/components/SearchForm/SearchForm.astro
@@ -6,6 +6,7 @@ interface Props {
   query: string;
 }
 const { query } = Astro.props;
+// const instanceId = Math.random().toString(36).substring(2); // @todo: fix multiple instances while supporting deep linking?
 const inputId = queryParamName;
 const hintId = `${ queryParamName }-hint`;
 ---

--- a/src/components/SearchForm/SearchForm.astro
+++ b/src/components/SearchForm/SearchForm.astro
@@ -3,29 +3,27 @@ import { t } from '~/lib/i18n';
 import { hasValidQuery, minQueryLength, getSearchPathname, queryParamName } from '~/lib/search';
 
 interface Props {
-  query: string;
+    query: string;
+    blockId?: string;
 }
-const { query } = Astro.props;
-// const instanceId = Math.random().toString(36).substring(2); // @todo: fix multiple instances while supporting deep linking?
-const inputId = queryParamName;
-const hintId = `${ queryParamName }-hint`;
+const { query, blockId } = Astro.props;
 ---
 
 <form method="GET" action={ getSearchPathname() } role="search">
   { query && !hasValidQuery(query) && (
-    <a id={ hintId } href={ `#${inputId}` } style="display:block;">
+    <a id={ `search-${blockId}-hint` } href={ `#search-${blockId}` } style="display:block;">
       { t('search_query_invalid', { query, minQueryLength }) }
     </a>
   ) }
-  <label for={ queryParamName }>{ t('search_label') }</label>
+  <label for={ `search-${blockId}` }>{ t('search_label') }</label>
   <input
     type="search"
-    id={ inputId }
+    id={ `search-${blockId}` }
     name={ queryParamName }
     value={ query }
     placeholder={ t('search_label') }
     minlength={ minQueryLength }
-    aria-describedby={ hintId }
+    aria-describedby={ `search-${blockId}-hint` }
     required
   />
   <button type="submit">{ t('search') }</button>

--- a/src/components/SearchForm/SearchForm.astro
+++ b/src/components/SearchForm/SearchForm.astro
@@ -9,7 +9,7 @@ import {
 
 interface Props {
   query: string;
-  blockId?: string;
+  blockId: string;
 }
 const { query, blockId } = Astro.props;
 ---

--- a/src/components/SearchForm/SearchForm.astro
+++ b/src/components/SearchForm/SearchForm.astro
@@ -1,30 +1,41 @@
 ---
 import { t } from '~/lib/i18n';
-import { hasValidQuery, minQueryLength, getSearchPathname, queryParamName } from '~/lib/search';
+import {
+  hasValidQuery,
+  minQueryLength,
+  getSearchPathname,
+  queryParamName,
+} from '~/lib/search';
 
 interface Props {
-    query: string;
-    blockId?: string;
+  query: string;
+  blockId?: string;
 }
 const { query, blockId } = Astro.props;
 ---
 
-<form method="GET" action={ getSearchPathname() } role="search">
-  { query && !hasValidQuery(query) && (
-    <a id={ `search-${blockId}-hint` } href={ `#search-${blockId}` } style="display:block;">
-      { t('search_query_invalid', { query, minQueryLength }) }
-    </a>
-  ) }
-  <label for={ `search-${blockId}` }>{ t('search_label') }</label>
+<form method="GET" action={getSearchPathname()} role="search">
+  {
+    query && !hasValidQuery(query) && (
+      <a
+        id={`search-${blockId}-hint`}
+        href={`#search-${blockId}`}
+        style="display:block;"
+      >
+        {t('search_query_invalid', { query, minQueryLength })}
+      </a>
+    )
+  }
+  <label for={`search-${blockId}`}>{t('search_label')}</label>
   <input
     type="search"
-    id={ `search-${blockId}` }
-    name={ queryParamName }
-    value={ query }
-    placeholder={ t('search_label') }
-    minlength={ minQueryLength }
-    aria-describedby={ `search-${blockId}-hint` }
+    id={`search-${blockId}`}
+    name={queryParamName}
+    value={query}
+    placeholder={t('search_label')}
+    minlength={minQueryLength}
+    aria-describedby={`search-${blockId}-hint`}
     required
   />
-  <button type="submit">{ t('search') }</button>
+  <button type="submit">{t('search')}</button>
 </form>

--- a/src/components/SearchForm/SearchForm.astro
+++ b/src/components/SearchForm/SearchForm.astro
@@ -12,11 +12,12 @@ interface Props {
   blockId: string;
 }
 const { query, blockId } = Astro.props;
+const hasHint = query && !hasValidQuery(query);
 ---
 
 <form method="GET" action={getSearchPathname()} role="search">
   {
-    query && !hasValidQuery(query) && (
+    hasHint && (
       <a
         id={`search-${blockId}-hint`}
         href={`#search-${blockId}`}
@@ -34,7 +35,7 @@ const { query, blockId } = Astro.props;
     value={query}
     placeholder={t('search_label')}
     minlength={minQueryLength}
-    aria-describedby={`search-${blockId}-hint`}
+    aria-describedby={hasHint ? `search-${blockId}-hint` : undefined}
     required
   />
   <button type="submit">{t('search')}</button>

--- a/src/content/Pages/CollectionEntry.query.graphql
+++ b/src/content/Pages/CollectionEntry.query.graphql
@@ -10,6 +10,7 @@
 #import '~/blocks/VideoEmbedBlock/VideoEmbedBlock.fragment.graphql'
 #import '~/blocks/GroupingBlock/GroupingBlock.fragment.graphql'
 #import '~/blocks/ListBlock/ListBlockFragment.graphql'
+#import '~/blocks/SearchFormBlock/SearchFormBlock.fragment.graphql'
 
 query PageCollectionEntry($locale: SiteLocale!, $slug: String!) {
   record: page(locale: $locale, filter: { slug: { eq: $slug } }) {
@@ -54,6 +55,9 @@ query PageCollectionEntry($locale: SiteLocale!, $slug: String!) {
       }
       ... on ListBlockRecord {
         ...ListBlock
+      }
+      ... on SearchFormBlockRecord {
+        ...SearchFormBlock
       }
     }
   }

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -7,7 +7,6 @@ import type { NotFoundPageQuery } from '~/lib/datocms/types';
 import type { SiteLocale } from '~/lib/datocms/schema';
 import { defaultLocale, isLocale } from '~/lib/i18n';
 import { noIndexTag, titleTag } from '~/lib/seo';
-import SearchFormBlock from '~/blocks/SearchFormBlock/SearchFormBlock.astro';
 import query from './_404.query.graphql';
 
 export const prerender = false;
@@ -30,16 +29,4 @@ const { page } = await datocmsRequest<NotFoundPageQuery, true>({ query, variable
   <PreviewModeSubscription query={query} variables={variables} />
   <h1>{page.title}</h1>
   <Blocks blocks={page.bodyBlocks} />
-
-  <h2>Search Form block: default (no query)</h2>
-  <SearchFormBlock block={{ query: '' }} />
-
-  <h2>Search Form block: query from CMS</h2>
-  <SearchFormBlock block={{ query: 'text' }} />
-
-  <h2>Search Form block: query from URL</h2>
-  <SearchFormBlock block={{ query: '' }} />
-
-  <h2>Search Form block: query from path</h2>
-  <SearchFormBlock block={{ query: '' }} />
 </Layout>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -7,6 +7,7 @@ import type { NotFoundPageQuery } from '~/lib/datocms/types';
 import type { SiteLocale } from '~/lib/datocms/schema';
 import { defaultLocale, isLocale } from '~/lib/i18n';
 import { noIndexTag, titleTag } from '~/lib/seo';
+import SearchFormBlock from '~/blocks/SearchFormBlock/SearchFormBlock.astro';
 import query from './_404.query.graphql';
 
 export const prerender = false;
@@ -29,4 +30,16 @@ const { page } = await datocmsRequest<NotFoundPageQuery, true>({ query, variable
   <PreviewModeSubscription query={query} variables={variables} />
   <h1>{page.title}</h1>
   <Blocks blocks={page.bodyBlocks} />
+
+  <h2>Search Form block: default (no query)</h2>
+  <SearchFormBlock block={{ query: '' }} />
+
+  <h2>Search Form block: query from CMS</h2>
+  <SearchFormBlock block={{ query: 'text' }} />
+
+  <h2>Search Form block: query from URL</h2>
+  <SearchFormBlock block={{ query: '' }} />
+
+  <h2>Search Form block: query from path</h2>
+  <SearchFormBlock block={{ query: '' }} />
 </Layout>

--- a/src/pages/[locale]/_index.query.graphql
+++ b/src/pages/[locale]/_index.query.graphql
@@ -8,6 +8,7 @@
 #import '~/blocks/VideoBlock/VideoBlock.fragment.graphql'
 #import '~/blocks/VideoEmbedBlock/VideoEmbedBlock.fragment.graphql'
 #import '~/blocks/GroupingBlock/GroupingBlock.fragment.graphql'
+#import '~/blocks/SearchFormBlock/SearchFormBlock.fragment.graphql'
 
 query HomePage($locale: SiteLocale!) {
   page: homePage(locale: $locale) {
@@ -50,6 +51,9 @@ query HomePage($locale: SiteLocale!) {
       }
       ... on GroupingBlockRecord {
         ...GroupingBlock
+      }
+      ... on SearchFormBlockRecord {
+        ...SearchFormBlock
       }
     }
   }

--- a/src/pages/[locale]/search/index.astro
+++ b/src/pages/[locale]/search/index.astro
@@ -6,7 +6,7 @@ import type { SiteLocale } from '~/lib/datocms/schema';
 import type { Breadcrumb } from '~/lib/routing';
 import { hasValidQuery, getSearchPathname, queryParamName } from '~/lib/search';
 import Layout from '~/layouts/Default.astro';
-import SearchForm from '~/components/SearchForm.astro';
+import SearchForm from '~/components/SearchForm/SearchForm.astro';
 import SearchResult from '~/components/SearchResult.astro';
 export const prerender = false;
 

--- a/src/pages/[locale]/search/index.astro
+++ b/src/pages/[locale]/search/index.astro
@@ -28,7 +28,7 @@ const breadcrumbs = [
   seoMetaTags={[ noIndexTag, titleTag(pageTitle) ]}
 >
   <h1>{ pageTitle }</h1>
-  <SearchForm query={ query } />
+  <SearchForm query={ query } blockId={ queryParamName } />
   { hasValidQuery(query) && (
     <section>
       <h2>{

--- a/src/pages/_404.query.graphql
+++ b/src/pages/_404.query.graphql
@@ -7,6 +7,7 @@
 #import '~/blocks/TextImageBlock/TextImageBlock.fragment.graphql'
 #import '~/blocks/VideoBlock/VideoBlock.fragment.graphql'
 #import '~/blocks/VideoEmbedBlock/VideoEmbedBlock.fragment.graphql'
+#import '~/blocks/SearchFormBlock/SearchFormBlock.fragment.graphql'
 
 query NotFoundPage($locale: SiteLocale!) {
   page: notFoundPage(locale: $locale) {
@@ -41,6 +42,9 @@ query NotFoundPage($locale: SiteLocale!) {
       }
       ... on VideoEmbedBlockRecord {
         ...VideoEmbedBlock
+      }
+      ... on SearchFormBlockRecord {
+        ...SearchFormBlock
       }
     }
   }


### PR DESCRIPTION
# Changes

- Adds a content block that allows editors to add a search form to any page.
- The search form is connected to the search page.
- The search input is pre-filled with a query from the CMS / search param / path name. 
- Adds search form block's README.
- Order of what is filled in in the search form is -> 1. query from dato, 2. query from url, 3. path from url, 4. nothing. 

# Associated issue

Resolves #165

# How to test

1. Open preview link
2. Navigate to a page that does not exist: `/en/not-found/anywhere`.
7. Verify that the Search Form block use the path name if there is no query in the url or filled in from dato.
8. Change the URL to include a `query` search parameter, like: `/en/not-found?query=some-text`.
9. Verify that the other search form inputs use this `query` value.
10. Verify that the Search Form block can contain the query from dato and overwrites the query and path from the url.
11. Verify that you can use multiple search form blocks on one page.
12. Verify that deeplinks in the searchlinks still work. Example: search result has a link under it, which goes to a certain part of the page with the use of #

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
