### PR TITLE
fix: set sameSite property to 'lax' to make cookie work when navigating from external site

### DIFF
--- a/src/pages/api/preview/enter.ts
+++ b/src/pages/api/preview/enter.ts
@@ -7,9 +7,11 @@ export const prerender = false;
 export const cookiePath = '/';
 
 export const GET: APIRoute = async ({ cookies, locals, request }) => {
-
   if (!locals.previewSecret) {
-    return new Response('Configure HEAD_START_PREVIEW_SECRET to enable preview mode', { status: 500 });
+    return new Response(
+      'Configure HEAD_START_PREVIEW_SECRET to enable preview mode',
+      { status: 500 },
+    );
   }
 
   const userSecret = new URL(request.url).searchParams.get('secret');
@@ -18,15 +20,15 @@ export const GET: APIRoute = async ({ cookies, locals, request }) => {
       httpOnly: true,
       secure: PUBLIC_IS_PRODUCTION,
       path: cookiePath,
-      sameSite: 'strict',
+      sameSite: 'lax',
       maxAge: 60 * 60 * 24 * 7, // 1 week
     });
   }
 
   // We don't redirect to location as that might lead to open redirect vulnerabilities
   const location = new URL(request.url).searchParams.get('location') || '/';
-  return new Response('',{
+  return new Response('', {
     status: 307,
-    headers: { 'Location': location },
+    headers: { Location: location },
   });
 };


### PR DESCRIPTION
# Changes

Set `sameSite: 'lax'` for the preview mode cookie, otherwise it will not work when linked from a link on a page of a different domain. This is currently happening when linking to the preview mode url from Dato, where it always prompts for the secret, even when it's included in the url.

# How to test

Enter the preview mode endpoint with the configured secret from a link on a page and see if it directly goes into preview mode instead of prompting for the secret.

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [ ] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
