### PR TITLE
Add video block hint (help text) 

### DIFF
--- a/config/datocms/migrations/1769163592_featVideoBlockHint.ts
+++ b/config/datocms/migrations/1769163592_featVideoBlockHint.ts
@@ -1,0 +1,12 @@
+import { Client } from '@datocms/cli/lib/cma-client-node';
+
+export default async function (client: Client) {
+  console.log('Update existing fields/fieldsets');
+
+  console.log(
+    'Update Single asset field "Video" (`video_asset`) in block model "\uD83C\uDFAC Video Block" (`video_block`)',
+  );
+  await client.fields.update('KdXhYelkQdaepb_wpK7yuw', {
+    hint: '\u26A0\uFE0F Note! Video streaming time is part of the variable costs of your Dato CMS plan.',
+  });
+}

--- a/datocms-environment.ts
+++ b/datocms-environment.ts
@@ -2,5 +2,5 @@
  * @see docs/getting-started.md on how to use this file
  * @see docs/decision-log/2023-10-24-datocms-env-file.md on why file is preferred over env vars
  */
-export const datocmsEnvironment = 'phone-number-plugin';
+export const datocmsEnvironment = 'feat-video-block-hint';
 export const datocmsBuildTriggerId = '34548';


### PR DESCRIPTION
# Changes
Added a help text for video blocks


# Associated issue

#307 

# How to test

- Go to any page and try to add a Video Block 
- See there is a warning under the field
<img width="1007" height="474" alt="SCR-20260123-jjgo" src="https://github.com/user-attachments/assets/7919f505-9802-4837-84c5-606a57069325" />

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [ ] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
