### PR TITLE
Readme's blocks and components in page partials for demo pages

### DIFF
--- a/config/datocms/scripts/seed-docs.ts
+++ b/config/datocms/scripts/seed-docs.ts
@@ -25,7 +25,6 @@ const client = buildClient({
 const docExtension = '.md';
 const docDirectory = path.resolve(rootDir,'docs/');
 const blockDirectory = path.resolve(rootDir,'src/blocks/');
-const componentDirectory = path.resolve(rootDir,'src/components/');
 const modelType = 'page';
 const documentationSlug = 'documentation';
 const mainBranchUrl = 'https://github.com/voorhoede/head-start/tree/main/';
@@ -221,7 +220,7 @@ async function markdownToStructuredText(markdown: string) {
   return structuredText;
 }
 
-function resolveLinks (mdast: Root) {
+function resolveLinks(mdast: Root) {
   visit(mdast, 'link', (node) => {
     if (node.url.startsWith('./') && node.url.includes('.md')) {
       node.url = node.url
@@ -253,7 +252,6 @@ async function seedDocs() {
   }
   await upsertDocPartialIndex(documents);
   await seedSrcDocs(blockDirectory, 'blocks');
-  await seedSrcDocs(componentDirectory, 'components');
 }
 
 seedDocs()


### PR DESCRIPTION
# Changes

- Creates or updates page partials based on the `README.md` per block by running `npm run seed:docs`
- This page partial can be added above the demo of that block on its demo page

# Associated issue

Resolves #328

# How to test

- Create a new env based on `feat-counter-block` in dato CMS
- Change the `datocmsEnvironment` to this env (in order to test this command and not change anything to the primary environment while testing)
- Run `npm run seed:docs`
- You'll see something logged in the terminal like this:
```
❗Missing README in: ~/head-start/src/blocks/CounterBlock
❗Missing README in: ~/head-start/src/blocks/TextImageBlock
✨ updated page partial: Documentation ActionBlock
✨ updated page partial: Documentation EmbedBlock
✅ Docs seeded
```
- To verify if it worked
  - Check if you see the page partials in the Page Partial Block Library
  - Check if content has changed if needed

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- [x] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
