### PR TITLE
Add devcontainer config to use tools containerized such as Claude code or copilot

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+{
+  "name": "Astro + Claude Code + Copilot",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24",
+
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+
+  "remoteUser": "node",
+  "containerUser": "node",
+
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/${localWorkspaceFolderBasename},type=bind,consistency=cached",
+
+  "mounts": [
+    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume"
+  ],
+
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "astro-build.astro-vscode",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "anthropic.claude-code",
+        "GitHub.copilot",
+        "GitHub.copilot-chat"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "github.copilot.enable": {
+          "*": true,
+          "plaintext": false,
+          "markdown": true,
+          "scminput": false
+        }
+      }
+    }
+  },
+
+  "remoteEnv": {
+    "NODE_ENV": "development"
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Installing project dependencies..."
+if [ -f "package-lock.json" ]; then
+  npm ci
+else
+  echo "No package-lock.json found, running npm install..."
+  npm install
+fi
+
+echo "==> Installing Claude Code..."
+npm install -g @anthropic-ai/claude-code
+
+echo "==> Setup complete."
+echo ""
+echo "Run 'claude' to start Claude Code."
+echo "Copilot will prompt you to sign in on first use."

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,8 +5,9 @@ echo "==> Installing project dependencies..."
 if [ -f "package-lock.json" ]; then
   npm ci
 else
-  echo "No package-lock.json found, running npm install..."
-  npm install
+  echo "Error: package-lock.json is required for deterministic devcontainer setup." >&2
+  echo "Please commit package-lock.json and rebuild the container." >&2
+  exit 1
 fi
 
 echo "==> Installing Claude Code..."


### PR DESCRIPTION
# Changes

- Adds a `.devcontainer` folder
- Adds devcontainer config including some tools and extensions
- Adds post-create script that install deps

# How to test
## Test file
1. Create a canary file somewhere in your system, i.e.
```bash
echo "SECRET_CANARY_VALUE_$(date +%s)" > ~/isolation-canary.txt
cat ~/isolation-canary.txt
```
## Start up container
### Vscode
1. Open in vscode
1. CMD+SHIFT+P "reopen in devcontainer"

### CLI
1. `devcontainer up`

## Test an agent
1. Try to cat the canary file from within the terminal in the container
1. Ask claude or copilot to locate the canary file

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
