### PR TITLE
Improve media blocks with subtitles, consent, chapters track

### DIFF
--- a/config/datocms/migrations/1706210000_translations.ts
+++ b/config/datocms/migrations/1706210000_translations.ts
@@ -71,6 +71,7 @@ export default async function (client: Client) {
       '{{ service }} uses cookies to show this video. This requires your permission.',
     'consent_message_embed_service':
       '{{ service }} uses cookies to show this content. This requires your permission.',
+    'load_embed_service': 'Load {{ service }} content',
     'skip_to_content': 'Skip to content',
     'not_found': 'The page you requested could not be found.',
     'watch_video_on_provider': 'watch on {{provider}}',

--- a/config/datocms/migrations/1706210000_translations.ts
+++ b/config/datocms/migrations/1706210000_translations.ts
@@ -69,6 +69,8 @@ export default async function (client: Client) {
     'select_language': 'Select language',
     'consent_message_service':
       '{{ service }} uses cookies to show this video. This requires your permission.',
+    'consent_message_embed_service':
+      '{{ service }} uses cookies to show this content. This requires your permission.',
     'skip_to_content': 'Skip to content',
     'not_found': 'The page you requested could not be found.',
     'watch_video_on_provider': 'watch on {{provider}}',

--- a/config/datocms/migrations/1706220000_pages.ts
+++ b/config/datocms/migrations/1706220000_pages.ts
@@ -725,7 +725,7 @@ export default async function (client: Client) {
     field_type: 'links',
     api_key: 'tracks',
     hint:
-      'For accessibility, videos should provide both captions and transcripts that accurately describe its content. Captions allow people who are experiencing hearing loss to understand a video\'s audio content as the video is being played, while transcripts allow people who need additional time to be able to review audio content at a pace and format that is comfortable for them.',
+      'For accessibility, videos should provide both captions and transcripts that accurately describe its content. Captions allow people who are experiencing hearing loss to understand a video\'s audio content as the video is being played, while transcripts allow people who need additional time to be able to review audio content at a pace and format that is comfortable for them. Use this field for chapters, descriptions, or metadata tracks only. Subtitles and closed captions must be added directly on the video asset itself (e.g. in the media library), not here.',
     validators: {
       items_item_type: {
         on_publish_with_unpublished_references_strategy: 'fail',
@@ -795,8 +795,6 @@ export default async function (client: Client) {
       required: {},
       enum: {
         values: [
-          'subtitles',
-          'captions',
           'descriptions',
           'chapters',
           'metadata',
@@ -808,7 +806,7 @@ export default async function (client: Client) {
       editor: 'single_line',
       parameters: { heading: false, placeholder: null },
     },
-    default_value: 'subtitles',
+    default_value: 'chapters',
   });
 
   console.log(

--- a/src/blocks/EmbedBlock/EmbedBlock.astro
+++ b/src/blocks/EmbedBlock/EmbedBlock.astro
@@ -23,13 +23,13 @@ const isProvider = (name: string) =>
   {
     data && data.html ? (
       isProvider('Twitter') ? (
-        <TwitterEmbed {data} {url} />
+        <TwitterEmbed {data} {url} blockId={block.id} />
       ) : isProvider('Vimeo') ? (
         <VimeoEmbed {data} {url} />
       ) : isProvider('YouTube') ? (
         <YouTubeEmbed {data} {url} />
       ) : (
-        <DefaultEmbed {data} {url} />
+        <DefaultEmbed {data} {url} blockId={block.id} />
       )
     ) : (
       <BasicEmbed {data} {url} />

--- a/src/blocks/EmbedBlock/EmbedBlock.test.ts
+++ b/src/blocks/EmbedBlock/EmbedBlock.test.ts
@@ -30,7 +30,7 @@ describe('EmbedBlock', () => {
     expect(fragment.querySelector('[data-provider="Twitter"]')).toBeTruthy();
   });
 
-  test('renders a Flickr embed block correctly', async () => {
+  test('renders a Flickr embed block correctly and shows consent alert for script-based embeds', async () => {
     const fragment = await renderToFragment<Props>(EmbedBlock, {
       props: {
         block: {
@@ -47,7 +47,8 @@ describe('EmbedBlock', () => {
             width: 1024,
             height: 683,
             web_page: 'https://www.flickr.com/photos/danielcheong/50416691972/',
-            thumbnail_url: 'https://live.staticflickr.com/65535/50416691972_d17d04862f_q.jpg',
+            thumbnail_url:
+              'https://live.staticflickr.com/65535/50416691972_d17d04862f_q.jpg',
             thumbnail_width: 150,
             thumbnail_height: 150,
             web_page_short_url: 'https://flic.kr/p/2jP9J2S',
@@ -64,9 +65,10 @@ describe('EmbedBlock', () => {
 
     expect(fragment.querySelector('default-embed')).toBeTruthy();
     expect(fragment.querySelector('[data-provider="Flickr"]')).toBeTruthy();
+    expect(fragment.querySelector('.consent-alert')).toBeTruthy();
   });
 
-  test('renders a CodePen embed block correctly', async () => {
+  test('renders a CodePen embed block correctly, shows consent alert and load button for iframe embeds with thumbnail', async () => {
     const fragment = await renderToFragment<Props>(EmbedBlock, {
       props: {
         block: {
@@ -86,8 +88,9 @@ describe('EmbedBlock', () => {
             width: '800',
             thumbnail_width: '384',
             thumbnail_height: '225',
-            thumbnail_url: 'https://shots.codepen.io/username/pen/epQNqN-512.jpg?version=1447132171',
-            html: '<iframe id="cp_embed_epQNqN" src="https://codepen.io/mattdesl/embed/preview/epQNqN?default-tabs=js%2Cresult&amp;height=300&amp;host=https%3A%2F%2Fcodepen.io&amp;slug-hash=epQNqN" title="Junk Pile - #codevember" scrolling="no" frameborder="0" height="300" allowtransparency="true" class="cp_embed_iframe" style="width: 100%; overflow: hidden;"></iframe>'
+            thumbnail_url:
+              'https://shots.codepen.io/username/pen/epQNqN-512.jpg?version=1447132171',
+            html: '<iframe id="cp_embed_epQNqN" src="https://codepen.io/mattdesl/embed/preview/epQNqN?default-tabs=js%2Cresult&amp;height=300&amp;host=https%3A%2F%2Fcodepen.io&amp;slug-hash=epQNqN" title="Junk Pile - #codevember" scrolling="no" frameborder="0" height="300" allowtransparency="true" class="cp_embed_iframe" style="width: 100%; overflow: hidden;"></iframe>',
           },
         },
       },
@@ -95,6 +98,34 @@ describe('EmbedBlock', () => {
 
     expect(fragment.querySelector('default-embed')).toBeTruthy();
     expect(fragment.querySelector('[data-provider="CodePen"]')).toBeTruthy();
+    expect(fragment.querySelector('.consent-alert')).toBeTruthy();
+    expect(fragment.querySelector('.load-button')).toBeTruthy();
+  });
+
+  test('omits consent alert for plain HTML embeds without iframe or scripts', async () => {
+    const fragment = await renderToFragment<Props>(EmbedBlock, {
+      props: {
+        block: {
+          id: '123',
+          url: 'https://example.com/quote',
+          data: {
+            provider_name: 'Example',
+            url: 'https://example.com/quote',
+            type: 'rich',
+            version: '1.0',
+            title: 'A quote',
+            author_name: 'Author',
+            author_url: 'https://example.com',
+            width: 400,
+            height: 200,
+            provider_url: 'https://example.com',
+            html: '<blockquote><p>Some content without tracking.</p></blockquote>',
+          },
+        },
+      },
+    });
+
+    expect(fragment.querySelector('.consent-alert')).toBeNull();
   });
 
   test('renders a YouTube embed block correctly', async () => {
@@ -117,7 +148,7 @@ describe('EmbedBlock', () => {
             thumbnail_height: 360,
             thumbnail_width: 480,
             thumbnail_url: 'https://i.ytimg.com/vi/feylP4p1-KU/hqdefault.jpg',
-            html: '<iframe width="200" height="113" src="https://www.youtube.com/embed/feylP4p1-KU?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen title="Green Caravan pitch (NL)"></iframe>'
+            html: '<iframe width="200" height="113" src="https://www.youtube.com/embed/feylP4p1-KU?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen title="Green Caravan pitch (NL)"></iframe>',
           },
         },
       },
@@ -148,14 +179,17 @@ describe('EmbedBlock', () => {
             width: 372,
             height: 360,
             duration: 35,
-            description: 'Companion article: https://www.voorhoede.nl/en/blog/enriching-rich-text-with-inline-components-datocms-react/',
-            thumbnail_url: 'https://i.vimeocdn.com/video/1290514162-5999b7e95c88cad3fe8cfcff2a3e1bd3a6e6cf4fe322cb95a_295x166',
+            description:
+              'Companion article: https://www.voorhoede.nl/en/blog/enriching-rich-text-with-inline-components-datocms-react/',
+            thumbnail_url:
+              'https://i.vimeocdn.com/video/1290514162-5999b7e95c88cad3fe8cfcff2a3e1bd3a6e6cf4fe322cb95a_295x166',
             thumbnail_width: 295,
             thumbnail_height: 286,
-            thumbnail_url_with_play_button: 'https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F1290514162-5999b7e95c88cad3fe8cfcff2a3e1bd3a6e6cf4fe322cb95a_295x166&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png',
+            thumbnail_url_with_play_button:
+              'https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F1290514162-5999b7e95c88cad3fe8cfcff2a3e1bd3a6e6cf4fe322cb95a_295x166&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png',
             upload_date: '2021-11-02 10:17:54',
             video_id: 641535920,
-            uri: '/videos/641535920'
+            uri: '/videos/641535920',
           },
         },
       },

--- a/src/blocks/EmbedBlock/README.md
+++ b/src/blocks/EmbedBlock/README.md
@@ -9,6 +9,8 @@
 - Lazy loads embed scripts and iframes to improve performance.
 - Provides a mechanism to define custom renderer per provider.
 - If OEmbed data is unavailable, a link is displayed with the page title of the given URL.
+- Has a responsive cover image that lazy loads image for better performance.
+- Requires user to give consent due to third party tracking (see #49: consent manager).
 
 ## Relevant links
 

--- a/src/blocks/EmbedBlock/embeds/Default.astro
+++ b/src/blocks/EmbedBlock/embeds/Default.astro
@@ -1,12 +1,15 @@
 ---
-import { extractScripts, getEmbedText, isIframeHtml, sanatizeHtml } from '../index';
+import { extractScripts, getEmbedText, isIframeHtml, sanitizeHtml } from '../index';
+import { t } from '~/lib/i18n';
+import Icon from '~/components/Icon';
 
 const { data, url, class: classList, ...props } = Astro.props;
 const { noscriptHtml, scripts } = extractScripts(data.html);
-const html = sanatizeHtml(noscriptHtml);
+const html = sanitizeHtml(noscriptHtml);
 const placeholderText = getEmbedText(data);
 const aspectRatio = data.width && data.height ? data.width / data.height : null;
 const maxWidth = data.width ? `${data.width}px` : '100%';
+const needsConsent = isIframeHtml(html) || scripts.length > 0;
 ---
 
 <default-embed 
@@ -34,6 +37,27 @@ const maxWidth = data.width ? `${data.width}px` : '100%';
       <script is:inline data-src={ src } {...attributes} />
     )) }
   </slot>
+  { needsConsent && (
+    <div class="consent-alert" role="alert" hidden>
+      <p class="consent-alert__text">
+        {t('consent_message_service', { service: data.provider_name })}
+      </p>
+      <div class="consent-alert__actions">
+        <button type="button" class="action--primary">
+          {t('allow_service', { service: data.provider_name })}
+        </button>
+        <a
+          href={url}
+          class="action--secondary"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {t('watch_video_on_provider', { provider: data.provider_name })}
+          <Icon name="external" />
+        </a>
+      </div>
+    </div>
+  )}
 </default-embed>
 
 <script src="./Default.client.ts"></script>
@@ -45,6 +69,7 @@ const maxWidth = data.width ? `${data.width}px` : '100%';
     max-width: var(--maxWidth);
     overflow: hidden;
     background-color: #ebebeb;
+    position: relative;
   }
 
   .embed-placeholder img {
@@ -54,7 +79,7 @@ const maxWidth = data.width ? `${data.width}px` : '100%';
     object-fit: cover;
     object-position: center;
   }
-  default-embed[data-enhanced="false"] .embed-placeholder {
+  default-embed[data-enhanced="false"] .embed-placeholder:not([hidden]) {
     display: block;
     width: 100%;
     height: 100%;
@@ -73,5 +98,26 @@ const maxWidth = data.width ? `${data.width}px` : '100%';
   default-embed :global(img) {
     max-width: 100% !important;
     height: auto !important;
+  }
+
+  .consent-alert:not([hidden]) {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 20px;
+    position: absolute;
+    inset: 0;
+    background-color: inherit;
+    z-index: 1;
+  }
+
+  .consent-alert__text {
+    max-width: 400px;
+    margin-inline: auto;
+    text-align: center;
+  }
+
+  .consent-alert__actions {
+    text-align: center;
   }
 </style>

--- a/src/blocks/EmbedBlock/embeds/Default.astro
+++ b/src/blocks/EmbedBlock/embeds/Default.astro
@@ -23,7 +23,12 @@ const needsConsent = isIframeHtml(html) || scripts.length > 0;
       ? (<>
         <a href={ url } rel="noreferrer noopener" target="_blank" class="embed-placeholder">
           { data.thumbnail_url
-            ? <img alt={ placeholderText } src={ data.thumbnail_url } loading="lazy" /> 
+            ? <>
+              <img alt={ placeholderText } src={ data.thumbnail_url } loading="lazy" />
+              <span class="load-button" aria-hidden="true">
+                {t('load_embed_service', { service: data.provider_name })}
+              </span>
+            </>
             : <span>{ placeholderText }</span>
           }
         </a>
@@ -81,11 +86,28 @@ const needsConsent = isIframeHtml(html) || scripts.length > 0;
   }
   default-embed[data-enhanced="false"] .embed-placeholder:not([hidden]) {
     display: block;
+    position: relative;
     width: 100%;
     height: 100%;
   }
   default-embed[data-enhanced="true"] .embed-placeholder {
     display: none;
+  }
+
+  .load-button {
+    position: absolute;
+    z-index: 1;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%) scale(1);
+    transition: transform 0.2s ease-in-out;
+    background-color: black;
+    padding: 0.5em;
+    color: white;
+  }
+  .embed-placeholder:hover .load-button,
+  .embed-placeholder:focus .load-button {
+    transform: translate(-50%, -50%) scale(1.1);
   }
 
   /* only force sizing on embeds with iframe in noscript html */

--- a/src/blocks/EmbedBlock/embeds/Default.astro
+++ b/src/blocks/EmbedBlock/embeds/Default.astro
@@ -3,7 +3,7 @@ import { extractScripts, getEmbedText, isIframeHtml, sanitizeHtml } from '../ind
 import { t } from '~/lib/i18n';
 import Icon from '~/components/Icon';
 
-const { data, url, class: classList, ...props } = Astro.props;
+const { data, url, blockId, class: classList, ...props } = Astro.props;
 const { noscriptHtml, scripts } = extractScripts(data.html);
 const html = sanitizeHtml(noscriptHtml);
 const placeholderText = getEmbedText(data);
@@ -43,8 +43,8 @@ const needsConsent = isIframeHtml(html) || scripts.length > 0;
     )) }
   </slot>
   { needsConsent && (
-    <div class="consent-alert" role="alert" hidden>
-      <p class="consent-alert__text">
+    <div class="consent-alert" role="dialog" aria-modal="true" aria-labelledby={`consent-text-${blockId}`} hidden>
+      <p id={`consent-text-${blockId}`} class="consent-alert__text">
         {t('consent_message_embed_service', { service: data.provider_name })}
       </p>
       <div class="consent-alert__actions">

--- a/src/blocks/EmbedBlock/embeds/Default.astro
+++ b/src/blocks/EmbedBlock/embeds/Default.astro
@@ -40,7 +40,7 @@ const needsConsent = isIframeHtml(html) || scripts.length > 0;
   { needsConsent && (
     <div class="consent-alert" role="alert" hidden>
       <p class="consent-alert__text">
-        {t('consent_message_service', { service: data.provider_name })}
+        {t('consent_message_embed_service', { service: data.provider_name })}
       </p>
       <div class="consent-alert__actions">
         <button type="button" class="action--primary">

--- a/src/blocks/EmbedBlock/embeds/Default.client.ts
+++ b/src/blocks/EmbedBlock/embeds/Default.client.ts
@@ -1,3 +1,16 @@
+import { persistentMap } from '@nanostores/persistent';
+
+type ConsentMap = Record<string, boolean>;
+
+const $consent = persistentMap<ConsentMap>(
+  'DefaultEmbed:consent:',
+  {},
+  {
+    decode: JSON.parse,
+    encode: JSON.stringify,
+  }
+);
+
 const enhanceIntersectedEmbeds = (entries: IntersectionObserverEntry[]) => {
   entries.forEach((entry) => {
     if (entry.isIntersecting && entry.target instanceof DefaultEmbed) {
@@ -16,31 +29,71 @@ class DefaultEmbed extends HTMLElement {
   #provider: string;
   #template?: HTMLTemplateElement;
   #scriptTags: HTMLScriptElement[] = [];
+  #consentAlert?: HTMLElement;
+  #consentButton?: HTMLButtonElement;
+  #placeholder?: HTMLAnchorElement;
 
   constructor() {
     super();
     this.#provider = this.dataset.provider || '';
     this.#template = this.querySelector('template') || undefined;
     this.#scriptTags = Array.from(this.querySelectorAll('script[data-src]'));
+    this.#consentAlert = (this.querySelector('[role="alert"]') as HTMLElement) ?? undefined;
+    this.#consentButton = (this.querySelector('[role="alert"] button') as HTMLButtonElement) ?? undefined;
+    this.#placeholder = (this.querySelector('.embed-placeholder') as HTMLAnchorElement) ?? undefined;
   }
 
   connectedCallback() {
+    this.#consentButton?.addEventListener('click', this.#grantConsent.bind(this));
+    this.#placeholder?.addEventListener('click', this.#onPlaceholderClick.bind(this));
     observer.observe(this);
+  }
+
+  disconnectedCallback() {
+    this.#consentButton?.removeEventListener('click', this.#grantConsent.bind(this));
+    this.#placeholder?.removeEventListener('click', this.#onPlaceholderClick.bind(this));
+  }
+
+  #hasConsent() {
+    return $consent.get()[this.#provider] === true;
+  }
+
+  #grantConsent() {
+    $consent.setKey(this.#provider, true);
+    this.#consentAlert?.setAttribute('hidden', '');
+    this.#load();
+  }
+
+  #onPlaceholderClick(event: MouseEvent) {
+    if (!this.#consentAlert) return;
+    event.preventDefault();
+    if (this.#hasConsent()) {
+      this.#load();
+    } else {
+      this.#placeholder?.setAttribute('hidden', '');
+      this.#consentAlert.removeAttribute('hidden');
+    }
   }
 
   enhance() {
     observer.unobserve(this);
 
+    if (!this.#template && this.#scriptTags.length === 0) return;
+    if (this.#placeholder && !this.#hasConsent()) return;
+
+    if (!this.#hasConsent()) {
+      this.#consentAlert?.removeAttribute('hidden');
+      return;
+    }
+
+    this.#load();
+  }
+
+  #load() {
     if (this.#isEnhanced) {
       return;
     }
     this.#isEnhanced = true;
-
-    if (!this.#template && this.#scriptTags.length === 0) {
-      return;
-    }
-  
-    console.log(`Todo: only enhance after consent for "${this.#provider}". See https://github.com/voorhoede/head-start/issues/49`);
 
     if (this.#template) {
       const clone = this.#template.content.cloneNode(true);

--- a/src/blocks/EmbedBlock/embeds/Default.client.ts
+++ b/src/blocks/EmbedBlock/embeds/Default.client.ts
@@ -32,6 +32,8 @@ class DefaultEmbed extends HTMLElement {
   #consentAlert?: HTMLElement;
   #consentButton?: HTMLButtonElement;
   #placeholder?: HTMLAnchorElement;
+  #boundGrantConsent: () => void;
+  #boundOnPlaceholderClick: (event: MouseEvent) => void;
 
   constructor() {
     super();
@@ -41,17 +43,20 @@ class DefaultEmbed extends HTMLElement {
     this.#consentAlert = (this.querySelector('[role="alert"]') as HTMLElement) ?? undefined;
     this.#consentButton = (this.querySelector('[role="alert"] button') as HTMLButtonElement) ?? undefined;
     this.#placeholder = (this.querySelector('.embed-placeholder') as HTMLAnchorElement) ?? undefined;
+    this.#boundGrantConsent = this.#grantConsent.bind(this);
+    this.#boundOnPlaceholderClick = this.#onPlaceholderClick.bind(this);
   }
 
   connectedCallback() {
-    this.#consentButton?.addEventListener('click', this.#grantConsent.bind(this));
-    this.#placeholder?.addEventListener('click', this.#onPlaceholderClick.bind(this));
+    this.#consentButton?.addEventListener('click', this.#boundGrantConsent);
+    this.#placeholder?.addEventListener('click', this.#boundOnPlaceholderClick);
     observer.observe(this);
   }
 
   disconnectedCallback() {
-    this.#consentButton?.removeEventListener('click', this.#grantConsent.bind(this));
-    this.#placeholder?.removeEventListener('click', this.#onPlaceholderClick.bind(this));
+    this.#consentButton?.removeEventListener('click', this.#boundGrantConsent);
+    this.#placeholder?.removeEventListener('click', this.#boundOnPlaceholderClick);
+    observer.unobserve(this);
   }
 
   #hasConsent() {

--- a/src/blocks/EmbedBlock/embeds/Default.client.ts
+++ b/src/blocks/EmbedBlock/embeds/Default.client.ts
@@ -40,8 +40,8 @@ class DefaultEmbed extends HTMLElement {
     this.#provider = this.dataset.provider || '';
     this.#template = this.querySelector('template') || undefined;
     this.#scriptTags = Array.from(this.querySelectorAll('script[data-src]'));
-    this.#consentAlert = (this.querySelector('[role="alert"]') as HTMLElement) ?? undefined;
-    this.#consentButton = (this.querySelector('[role="alert"] button') as HTMLButtonElement) ?? undefined;
+    this.#consentAlert = (this.querySelector('[role="dialog"]') as HTMLElement) ?? undefined;
+    this.#consentButton = (this.querySelector('[role="dialog"] button') as HTMLButtonElement) ?? undefined;
     this.#placeholder = (this.querySelector('.embed-placeholder') as HTMLAnchorElement) ?? undefined;
     this.#boundGrantConsent = this.#grantConsent.bind(this);
     this.#boundOnPlaceholderClick = this.#onPlaceholderClick.bind(this);
@@ -77,6 +77,7 @@ class DefaultEmbed extends HTMLElement {
     } else {
       this.#placeholder?.setAttribute('hidden', '');
       this.#consentAlert.removeAttribute('hidden');
+      this.#consentButton?.focus();
     }
   }
 
@@ -88,6 +89,7 @@ class DefaultEmbed extends HTMLElement {
 
     if (!this.#hasConsent()) {
       this.#consentAlert?.removeAttribute('hidden');
+      this.#consentButton?.focus();
       return;
     }
 

--- a/src/blocks/EmbedBlock/embeds/Twitter.astro
+++ b/src/blocks/EmbedBlock/embeds/Twitter.astro
@@ -6,10 +6,11 @@ import type { OEmbedRich } from '../index';
 
 const data = Astro.props.data as OEmbedRich;
 const url = Astro.props.url;
+const blockId = Astro.props.blockId;
 const { noscriptHtml } = extractScripts(data.html);
 ---
 
-<DefaultEmbed { data } { url } class="twitter-embed">
+<DefaultEmbed { data } { url } blockId={ blockId } class="twitter-embed">
   <div slot="html">
     <Icon name="twitter" aria-label={ data.provider_name } />
     <div

--- a/src/blocks/EmbedBlock/index.ts
+++ b/src/blocks/EmbedBlock/index.ts
@@ -92,7 +92,7 @@ export const isIframeHtml = (html: string): boolean => {
   return /<iframe[^>]*>/gi.test(html);
 };
 
-export const sanatizeHtml = (html: string): string => {
+export const sanitizeHtml = (html: string): string => {
   /**
    * Remove deprecated attributes to resolve HTML violations
    * https://html-validate.org/rules/no-deprecated-attr.html

--- a/src/blocks/VideoBlock/README.md
+++ b/src/blocks/VideoBlock/README.md
@@ -8,7 +8,8 @@
 - Supports video streaming with adaptive bitrate (using HLS) for best UX and performance.
 - Fallback to mp4 video when streaming is not available.
 - Fallback to video download link when HTML video element is not supported.
-- Supports subtitle tracks for enhanced accessibility, automatically selecting default locale when available.
+- Supports subtitle and closed captions tracks for enhanced accessibility, automatically selecting default locale when available.
+- Supports chapter tracks by adding buttons to navigate through the video. 
 - Supports figcaption defaulting to external video's title and optional custom title override.
 - Supports autoplay, mute and loop.
 - Autoplay is only triggered if no reduced motion is preferred (for a11y) and save data mode is off.

--- a/src/blocks/VideoBlock/VideoBlock.client.ts
+++ b/src/blocks/VideoBlock/VideoBlock.client.ts
@@ -17,6 +17,7 @@ const getHlsPlayer = () => import('hls.js');
 
 class VideoBlock extends HTMLElement {
   #autoplay = false;
+  #chaptersRendered = false;
   #mp4Url?: string;
   #streamingUrl?: string;
   #useReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -67,13 +68,17 @@ class VideoBlock extends HTMLElement {
   }
 
   #initChapters() {
+    if (this.#chaptersRendered) return;
     const chaptersTrack = [...this.#video.textTracks].find(t => t.kind === 'chapters');
     if (!chaptersTrack) return;
 
     const render = () => {
+      if (this.#chaptersRendered) return;
+      this.#chaptersRendered = true;
       chaptersTrack.mode = 'hidden';
       [...(chaptersTrack.cues ?? [])].forEach(cue => {
         const btn = document.createElement('button');
+        btn.type = 'button';
         btn.textContent = (cue as VTTCue).text;
         btn.addEventListener('click', () => { this.#video.currentTime = cue.startTime; });
         this.appendChild(btn);

--- a/src/blocks/VideoBlock/VideoBlock.client.ts
+++ b/src/blocks/VideoBlock/VideoBlock.client.ts
@@ -91,11 +91,13 @@ class VideoBlock extends HTMLElement {
    * HLS stream ignores <track default> attribute, so we enable it manually:
    */
   showTextTrack() {
-    const tracks = [...this.#video.textTracks].filter(t => t.kind === 'subtitles');
+    const tracks = [...this.#video.textTracks].filter(t => t.kind === 'subtitles' || t.kind === 'captions');
     const alreadyShowing = tracks.some(t => t.mode === 'showing');
     if (alreadyShowing) return;
 
-    const defaultTrack = tracks.find(t => t.language === getLocale());
+    const locale = getLocale();
+    const defaultTrack = tracks.find(t => t.language === locale && t.kind === 'subtitles')
+      ?? tracks.find(t => t.language === locale);
     if (defaultTrack) {
       defaultTrack.mode = 'showing';
     }

--- a/src/blocks/VideoBlock/VideoBlock.client.ts
+++ b/src/blocks/VideoBlock/VideoBlock.client.ts
@@ -53,6 +53,7 @@ class VideoBlock extends HTMLElement {
       this.addEventListener('click', this.#onClick.bind(this), { once: true });
     }
     videoBlockObserver.observe(this);
+    this.#initChapters();
   }
 
   disconnectedCallback() {
@@ -65,12 +66,36 @@ class VideoBlock extends HTMLElement {
     this.play({ focus: true });
   }
 
+  #initChapters() {
+    const chaptersTrack = [...this.#video.textTracks].find(t => t.kind === 'chapters');
+    if (!chaptersTrack) return;
+
+    const render = () => {
+      chaptersTrack.mode = 'hidden';
+      [...(chaptersTrack.cues ?? [])].forEach(cue => {
+        const btn = document.createElement('button');
+        btn.textContent = (cue as VTTCue).text;
+        btn.addEventListener('click', () => { this.#video.currentTime = cue.startTime; });
+        this.appendChild(btn);
+      });
+    };
+
+    if (chaptersTrack.cues?.length) {
+      render();
+    } else {
+      this.querySelector('track[kind="chapters"]')?.addEventListener('load', render, { once: true });
+    }
+  }
+
   /**
    * HLS stream ignores <track default> attribute, so we enable it manually:
    */
   showTextTrack() {
-    const defaultTrack = [...this.#video.textTracks]
-      .find((track) => track.language === getLocale());
+    const tracks = [...this.#video.textTracks].filter(t => t.kind === 'subtitles');
+    const alreadyShowing = tracks.some(t => t.mode === 'showing');
+    if (alreadyShowing) return;
+
+    const defaultTrack = tracks.find(t => t.language === getLocale());
     if (defaultTrack) {
       defaultTrack.mode = 'showing';
     }

--- a/src/blocks/VideoEmbedBlock/VideoEmbedBlock.astro
+++ b/src/blocks/VideoEmbedBlock/VideoEmbedBlock.astro
@@ -118,8 +118,8 @@ function getVideoUrl({
       />
     </PlayButton>
 
-    <div class="consent-alert" role="alert" hidden>
-      <p class="consent-alert__text">
+    <div class="consent-alert" role="dialog" aria-modal="true" aria-labelledby={`consent-text-${block.id}`} hidden>
+      <p id={`consent-text-${block.id}`} class="consent-alert__text">
         {t('consent_message_service', { service: providerName })}
       </p>
       <div class="consent-alert__actions">

--- a/src/blocks/VideoEmbedBlock/VideoEmbedBlock.client.ts
+++ b/src/blocks/VideoEmbedBlock/VideoEmbedBlock.client.ts
@@ -36,9 +36,9 @@ class VideoEmbed extends HTMLElement {
 
   constructor() {
     super();
-    this.#consentAlert = this.querySelector('[role="alert"]') as HTMLElement;
+    this.#consentAlert = this.querySelector('[role="dialog"]') as HTMLElement;
     this.#consentButton = this.querySelector(
-      '[role="alert"] button'
+      '[role="dialog"] button'
     ) as HTMLButtonElement;
     this.#anchor = this.querySelector('a') as HTMLAnchorElement;
     this.#iframe = this.querySelector('iframe') as HTMLIFrameElement;
@@ -105,6 +105,7 @@ class VideoEmbed extends HTMLElement {
     } else {
       this.#consentAlert.removeAttribute('hidden');
       this.#anchor.setAttribute('hidden', '');
+      this.#consentButton.focus();
     }
   }
 

--- a/src/blocks/VideoEmbedBlock/VideoEmbedBlock.client.ts
+++ b/src/blocks/VideoEmbedBlock/VideoEmbedBlock.client.ts
@@ -31,6 +31,8 @@ class VideoEmbed extends HTMLElement {
   #isPlaying = false;
   #provider: ConsentKey;
   #videoUrl: string;
+  #boundOnClick: (event: MouseEvent) => void;
+  #boundConsentAndPlay: () => void;
 
   constructor() {
     super();
@@ -43,6 +45,8 @@ class VideoEmbed extends HTMLElement {
     this.#autoplay = this.dataset.autoplay === 'true';
     this.#provider = this.dataset.provider as ConsentKey;
     this.#videoUrl = this.dataset.videoUrl as string;
+    this.#boundOnClick = this.#onClick.bind(this);
+    this.#boundConsentAndPlay = this.#consentAndPlay.bind(this);
   }
 
   connectedCallback() {
@@ -69,11 +73,8 @@ class VideoEmbed extends HTMLElement {
       return;
     }
 
-    this.#anchor.addEventListener('click', this.#onClick.bind(this));
-    this.#consentButton.addEventListener(
-      'click',
-      this.#consentAndPlay.bind(this)
-    );
+    this.#anchor.addEventListener('click', this.#boundOnClick);
+    this.#consentButton.addEventListener('click', this.#boundConsentAndPlay);
 
     const useReducedMotion = window.matchMedia(
       '(prefers-reduced-motion: reduce)'
@@ -84,11 +85,8 @@ class VideoEmbed extends HTMLElement {
   }
 
   disconnectedCallback() {
-    this.#anchor.removeEventListener('click', this.#onClick.bind(this));
-    this.#consentButton.removeEventListener(
-      'click',
-      this.#consentAndPlay.bind(this)
-    );
+    this.#anchor.removeEventListener('click', this.#boundOnClick);
+    this.#consentButton.removeEventListener('click', this.#boundConsentAndPlay);
   }
 
   #consentAndPlay() {


### PR DESCRIPTION
# Changes

- Adds consent manager for embed block.
- Updates docs
- Adds new translation strings
- Updates video block track handling
  - Subtitle and captions kind can be reomved from data field: track `kind`
   This is handled by the video asset details itself. Subtitles can also be auto generated
   - Adds buttons for every chapter when there is a chapters track added.

# Associated issue

Resolves #378

# How to test

1. Open preview link
2. Open de embed block demo page
3. Verify that you see the thumbnail
4. Verify that it asks consent using third party cookies. 
5. Verify it stores this answer in the localstorage

--- 

1. add a chapter track to a video in the video block
2. Open preview link
3. Verify that you see buttons and can click through the chapters of the video. 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
