### PR TITLE
feat: ai search component

### DIFF
--- a/config/datocms/migrations/1777550400_featAskAiTranslations.ts
+++ b/config/datocms/migrations/1777550400_featAskAiTranslations.ts
@@ -1,0 +1,63 @@
+import { Client } from '@datocms/cli/lib/cma-client-node';
+
+export default async function (client: Client) {
+  const translation = await client.itemTypes.find('translation');
+
+  const translationContent: Record<string, { en: string; nl: string }> = {
+    ask: {
+      en: 'Ask AI',
+      nl: 'Vraag AI',
+    },
+    ask_on_site: {
+      en: 'Ask {{ siteName }}',
+      nl: 'Vraag {{ siteName }}',
+    },
+    ask_intro: {
+      en: 'Ask a question and get an answer drawn from this site\'s content.',
+      nl: 'Stel een vraag en krijg een antwoord op basis van de content op deze site.',
+    },
+    ask_label: {
+      en: 'Ask a question',
+      nl: 'Stel een vraag',
+    },
+    ask_placeholder: {
+      en: 'Ask a question about this site…',
+      nl: 'Stel een vraag over deze site…',
+    },
+    ask_submit: {
+      en: 'Ask',
+      nl: 'Vraag',
+    },
+    ask_answer: {
+      en: 'Answer',
+      nl: 'Antwoord',
+    },
+    ask_sources: {
+      en: 'Sources',
+      nl: 'Bronnen',
+    },
+    ask_thinking: {
+      en: 'Thinking…',
+      nl: 'Bezig met nadenken…',
+    },
+    ask_empty: {
+      en: 'No answer found for that question.',
+      nl: 'Geen antwoord gevonden op die vraag.',
+    },
+    ask_error: {
+      en: 'Something went wrong. Please try again.',
+      nl: 'Er ging iets mis. Probeer het opnieuw.',
+    },
+  };
+
+  console.log('Create Ask AI translation content');
+  await Promise.all(
+    Object.entries(translationContent).map(([key, value]) =>
+      client.items.create({
+        item_type: { type: 'item_type', id: translation.id },
+        key,
+        value,
+      }),
+    ),
+  );
+}

--- a/config/datocms/migrations/1777550400_featAskAiTranslations.ts
+++ b/config/datocms/migrations/1777550400_featAskAiTranslations.ts
@@ -4,47 +4,47 @@ export default async function (client: Client) {
   const translation = await client.itemTypes.find('translation');
 
   const translationContent: Record<string, { en: string; nl: string }> = {
-    ask: {
+    ask_ai: {
       en: 'Ask AI',
       nl: 'Vraag AI',
     },
-    ask_on_site: {
+    ask_ai_on_site: {
       en: 'Ask {{ siteName }}',
       nl: 'Vraag {{ siteName }}',
     },
-    ask_intro: {
+    ask_ai_intro: {
       en: 'Ask a question and get an answer drawn from this site\'s content.',
       nl: 'Stel een vraag en krijg een antwoord op basis van de content op deze site.',
     },
-    ask_label: {
+    ask_ai_label: {
       en: 'Ask a question',
       nl: 'Stel een vraag',
     },
-    ask_placeholder: {
+    ask_ai_placeholder: {
       en: 'Ask a question about this site…',
       nl: 'Stel een vraag over deze site…',
     },
-    ask_submit: {
+    ask_ai_submit: {
       en: 'Ask',
       nl: 'Vraag',
     },
-    ask_answer: {
+    ask_ai_answer: {
       en: 'Answer',
       nl: 'Antwoord',
     },
-    ask_sources: {
+    ask_ai_sources: {
       en: 'Sources',
       nl: 'Bronnen',
     },
-    ask_thinking: {
+    ask_ai_thinking: {
       en: 'Thinking…',
       nl: 'Bezig met nadenken…',
     },
-    ask_empty: {
+    ask_ai_empty: {
       en: 'No answer found for that question.',
       nl: 'Geen antwoord gevonden op die vraag.',
     },
-    ask_error: {
+    ask_ai_error: {
       en: 'Something went wrong. Please try again.',
       nl: 'Er ging iets mis. Probeer het opnieuw.',
     },

--- a/config/datocms/migrations/1780321119_featAiChatTranslations.ts
+++ b/config/datocms/migrations/1780321119_featAiChatTranslations.ts
@@ -1,0 +1,71 @@
+import { Client } from '@datocms/cli/lib/cma-client-node';
+
+export default async function (client: Client) {
+  const translation = await client.itemTypes.find('translation');
+
+  const translationContent: Record<string, { en: string; nl: string }> = {
+    chat: {
+      en: 'Chat',
+      nl: 'Chat',
+    },
+    chat_on_site: {
+      en: 'Chat with {{ siteName }}',
+      nl: 'Chat met {{ siteName }}',
+    },
+    chat_intro: {
+      en: 'Ask follow-up questions and get answers drawn from this site\'s content.',
+      nl: 'Stel vervolgvragen en krijg antwoorden op basis van de content op deze site.',
+    },
+    chat_label: {
+      en: 'Ask a question',
+      nl: 'Stel een vraag',
+    },
+    chat_placeholder: {
+      en: 'Ask a question…',
+      nl: 'Stel een vraag…',
+    },
+    chat_submit: {
+      en: 'Send',
+      nl: 'Versturen',
+    },
+    chat_clear: {
+      en: 'Clear chat',
+      nl: 'Wis gesprek',
+    },
+    chat_thinking: {
+      en: 'Thinking…',
+      nl: 'Bezig met nadenken…',
+    },
+    chat_empty: {
+      en: 'No answer found for that question.',
+      nl: 'Geen antwoord gevonden op die vraag.',
+    },
+    chat_error: {
+      en: 'Something went wrong. Please try again.',
+      nl: 'Er ging iets mis. Probeer het opnieuw.',
+    },
+    chat_empty_state: {
+      en: 'Ask a question to start a conversation.',
+      nl: 'Stel een vraag om een gesprek te starten.',
+    },
+    chat_not_saved: {
+      en: 'This chat could not be saved. You can keep chatting, but refreshing the page will lose earlier messages.',
+      nl: 'Dit gesprek kon niet worden opgeslagen. Je kunt blijven chatten, maar als je de pagina ververst gaan eerdere berichten verloren.',
+    },
+    chat_context_divider: {
+      en: 'Messages above this line are out of the current context window.',
+      nl: 'Berichten boven deze lijn vallen buiten het huidige contextvenster.',
+    },
+  };
+
+  console.log('Create AI Chat translation content');
+  await Promise.all(
+    Object.entries(translationContent).map(([key, value]) =>
+      client.items.create({
+        item_type: { type: 'item_type', id: translation.id },
+        key,
+        value,
+      }),
+    ),
+  );
+}

--- a/datocms-environment.ts
+++ b/datocms-environment.ts
@@ -2,5 +2,5 @@
  * @see docs/getting-started.md on how to use this file
  * @see docs/decision-log/2023-10-24-datocms-env-file.md on why file is preferred over env vars
  */
-export const datocmsEnvironment = 'deploy-search-form';
+export const datocmsEnvironment = 'ai-search-deploy';
 export const datocmsBuildTriggerId = '34548';

--- a/docs/decision-log/2026-05-27-ai-chat-multiturn.md
+++ b/docs/decision-log/2026-05-27-ai-chat-multiturn.md
@@ -1,0 +1,23 @@
+# AI Chat (multi-turn)
+
+**Add multi-turn chat as a sibling to the existing single-question AI Search, sharing the same Cloudflare AI Search instance but exposed at a separate endpoint and page.**
+
+- Date: 2026-05-27
+- Alternatives Considered: extend `/api/ai-search` to accept either `{ query }` or `{ messages }`; replace single-question search entirely with chat; configurable DatoCMS block fields (intro text, placeholder); persist chat conversation server-side (Workers KV); skip persistence entirely
+- Decision Made By: [Ani](https://github.com/anareyna)
+
+## Decision
+
+The [AI Search prototype](./2026-05-20-ai-search-prototype.md) shipped a single-question search surface. Multi-turn chat is the natural next step on the same retrieval backend. Cloudflare AI Search's `chat/completions` endpoint already accepts an OpenAI-style `messages` array, so the upstream call is the same shape we use today; only the client contract changes.
+
+Chat ships as a **second endpoint** (`/api/ai-chat`) rather than extending `/api/ai-search`. Two reasons. First, the request shapes are different enough (`{ query }` vs `{ messages: [...] }`) that overloading the same route would mean either a discriminator field or content-type sniffing, both of which trade clarity for one fewer file. Second, it keeps the search proxy contract stable while chat iterates, so the existing search component does not need to re-handle either shape.
+
+Search and chat both stay live for now. The product call between "search is the surface" and "chat is the surface" is something we can only make once people use them; killing search before that signal exists would throw away working UX on a hunch. We can remove one later without breaking the other.
+
+History is capped to the **last 10 messages**, server-side, in the proxy. The cap protects token cost on Cloudflare's side and bounds the request size regardless of what the client sends. Clients should still trim locally for their own reasons (localStorage size, render perf), but the proxy is the source of truth. The cap is silent: if the client sends 30 messages, the proxy keeps the most recent 10 and, if the trim leaves an `assistant` message at the start, drops one more so the conversation begins with `user` (which Cloudflare requires). Raising the cap is a one-line change if we hit the ceiling.
+
+The chat UI ships as an `<ai-chat>` web component on a dedicated `/[locale]/chat/` route. A DatoCMS block that drops the component into any editor-built page is deferred to a later PR; this cut covers the standalone page only.
+
+Conversation state persists in `localStorage`, scoped per locale (`ai-chat:en`, `ai-chat:nl`, …), with a "Clear chat" button. Server-side persistence (KV per session, account) was rejected as overkill for a prototype: it would need session IDs, a TTL story, and a privacy stance, none of which we are ready to commit to. Browser-only state means a refresh keeps the chat (avoiding the "I lost my answer" frustration of fresh-on-every-load), but switching browsers or clearing storage wipes it. Per-locale scoping prevents an `nl` chat from leaking into the `en` view if the user switches language mid-conversation.
+
+The chat client reuses the streaming and markdown-rendering code already in `<ai-search>` by extracting `src/lib/ai-stream.ts` from `AiSearch.client.ts`. No new dependency, just shared internals once there are two callers.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -130,9 +130,12 @@ That's it. Now deployments are automatically triggered from both git and when ed
 
 ## Enable AI Search
 
-Head Start has an optional AI Search prototype that lets visitors ask natural-language questions about your site's content. It uses [Cloudflare AI Search](https://developers.cloudflare.com/ai-search/) to index your published pages (via the existing `/api/content/<path>.md` endpoint) and answer questions with citations. The query API is exposed at `/api/ai-search`.
+Head Start has an optional AI Search prototype that lets visitors ask natural-language questions about your site's content. It uses [Cloudflare AI Search](https://developers.cloudflare.com/ai-search/) to index your published pages (via the existing `/api/content/<path>.md` endpoint) and answer questions with citations. Two endpoints share the same setup:
 
-If you skip this section, builds and deploys still work. The `/api/ai-search` endpoint just returns a 503.
+- `/api/ai-search` for a single question + answer.
+- `/api/ai-chat` for multi-turn follow-ups. Accepts `{ messages: [{ role: 'user' | 'assistant', content }, ...] }`; the server caps history to the last 10 messages.
+
+If you skip this section, builds and deploys still work. The endpoints just return a 503.
 
 ### 1. Create an AI Search instance
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13530,6 +13530,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/marked": {
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.4.tgz",
+      "integrity": "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "hls.js": "^1.6.16",
     "html-validate": "^11.5.3",
     "jiti": "^2.7.0",
+    "marked": "^18.0.4",
     "nanostores": "^1.3.0",
     "oembed-providers": "^1.0.20260604",
     "pretty-bytes": "^7.1.0",

--- a/src/components/AiChat/AiChat.astro
+++ b/src/components/AiChat/AiChat.astro
@@ -1,0 +1,142 @@
+---
+import { getLocale, t } from '~/lib/i18n';
+import { siteName } from '~/lib/seo';
+
+/*
+ * <ai-chat> component: a conversation surface for /api/ai-chat. Messages persist
+ * in localStorage scoped per locale (key `ai-chat:<locale>`). A "Clear chat"
+ * button wipes both the UI and the stored history.
+ */
+
+const inputId = 'ai-chat-input';
+const locale = getLocale();
+---
+
+<ai-chat
+  data-locale={locale}
+  data-thinking-text={t('chat_thinking')}
+  data-empty-text={t('chat_empty')}
+  data-error-text={t('chat_error')}
+  data-context-divider-text={t('chat_context_divider')}
+>
+  <div class="ai-chat__head">
+    <h1>{t('chat_on_site', { siteName: siteName() })}</h1>
+    <p class="ai-chat__intro">
+      {t('chat_intro')}
+    </p>
+  </div>
+
+  <ol class="ai-chat__log" data-log aria-live="polite" aria-label={t('chat')}></ol>
+
+  <p class="ai-chat__empty" data-empty>{t('chat_empty_state')}</p>
+
+  <p class="ai-chat__notice" data-notice role="status" hidden>{t('chat_not_saved')}</p>
+
+  <form class="ai-chat__form" data-form>
+    <label class="a11y-sr-only" for={inputId}>{t('chat_label')}</label>
+    <textarea
+      class="ai-chat__input"
+      id={inputId}
+      name="message"
+      placeholder={t('chat_placeholder')}
+      rows="2"
+      required
+      data-input
+    ></textarea>
+    <div class="ai-chat__actions">
+      <button type="button" data-clear hidden>{t('chat_clear')}</button>
+      <button type="submit" data-submit>{t('chat_submit')}</button>
+    </div>
+  </form>
+</ai-chat>
+
+<script src="./AiChat.client.ts"></script>
+
+<style is:global>
+  ai-chat {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  ai-chat .ai-chat__intro {
+    margin-block: 0.25rem 1rem;
+  }
+  ai-chat .ai-chat__log {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  ai-chat .ai-chat__log:empty {
+    display: none;
+  }
+  ai-chat .ai-chat__empty {
+    color: #666;
+    font-style: italic;
+  }
+  ai-chat .ai-chat__notice {
+    margin: 0;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    background: #fff4e5;
+    color: #663c00;
+    font-size: 0.85em;
+  }
+  ai-chat .ai-chat__context-divider {
+    border-block-start: 1px solid #ddd;
+    text-align: center;
+    font-size: 0.75em;
+  }
+  ai-chat .ai-chat__message {
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    max-width: 80%;
+  }
+  ai-chat .ai-chat__message--user {
+    background: #eef2ff;
+    align-self: flex-end;
+  }
+  ai-chat .ai-chat__message--assistant {
+    background: #f5f5f5;
+    align-self: flex-start;
+  }
+  ai-chat .ai-chat__body > :first-child {
+    margin-block-start: 0;
+  }
+  ai-chat .ai-chat__body > :last-child {
+    margin-block-end: 0;
+  }
+  ai-chat .ai-chat__body pre {
+    padding: 0.5rem;
+    background: #fff;
+    font-size: 0.8em;
+    overflow-x: auto;
+  }
+  ai-chat .ai-chat__sources {
+    list-style: none;
+    margin: 0.5rem 0 0;
+    padding: 0;
+    font-size: 0.8em;
+  }
+  ai-chat .ai-chat__sources li {
+    margin-block-end: 0.25rem;
+  }
+  ai-chat .ai-chat__form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  ai-chat .ai-chat__input {
+    width: 100%;
+    font: inherit;
+    padding: 0.5rem;
+    resize: vertical;
+  }
+  ai-chat .ai-chat__actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+</style>

--- a/src/components/AiChat/AiChat.client.ts
+++ b/src/components/AiChat/AiChat.client.ts
@@ -1,0 +1,270 @@
+import {
+  readSseEvents,
+  parseChunks,
+  getDeltaContent,
+  renderMarkdown,
+  HISTORY_CAP,
+  type RetrievedChunk,
+  type Source,
+} from '~/lib/ai-stream';
+
+/*
+ * <ai-chat> custom element. Multi-turn conversation against /api/ai-chat.
+ *
+ * State lives in `this.#messages` and is mirrored to localStorage so a refresh
+ * keeps the conversation. The DOM is built from the same array, so any state
+ * change ends with a #render() (or a targeted DOM update during streaming).
+ */
+
+type Role = 'user' | 'assistant';
+type Message = { role: Role; content: string; sources?: Source[] };
+
+const STORAGE_PREFIX = 'ai-chat:';
+
+class AiChat extends HTMLElement {
+  #locale: string;
+  #form: HTMLFormElement;
+  #input: HTMLTextAreaElement;
+  #submit: HTMLButtonElement;
+  #clear: HTMLButtonElement;
+  #log: HTMLOListElement;
+  #empty: HTMLElement;
+  #notice: HTMLElement;
+  #messages: Message[] = [];
+
+  constructor() {
+    super();
+    this.#locale = this.dataset.locale ?? '';
+    this.#form = this.querySelector('[data-form]') as HTMLFormElement;
+    this.#input = this.querySelector('[data-input]') as HTMLTextAreaElement;
+    this.#submit = this.querySelector('[data-submit]') as HTMLButtonElement;
+    this.#clear = this.querySelector('[data-clear]') as HTMLButtonElement;
+    this.#log = this.querySelector('[data-log]') as HTMLOListElement;
+    this.#empty = this.querySelector('[data-empty]') as HTMLElement;
+    this.#notice = this.querySelector('[data-notice]') as HTMLElement;
+  }
+
+  connectedCallback() {
+    this.#messages = this.#loadHistory();
+    this.#render();
+
+    this.#form.addEventListener('submit', this.#handleSubmit);
+    this.#clear.addEventListener('click', this.#handleClear);
+    this.#input.addEventListener('keydown', this.#handleKeydown);
+  }
+
+  disconnectedCallback() {
+    this.#form.removeEventListener('submit', this.#handleSubmit);
+    this.#clear.removeEventListener('click', this.#handleClear);
+    this.#input.removeEventListener('keydown', this.#handleKeydown);
+  }
+
+  #storageKey() {
+    return `${STORAGE_PREFIX}${this.#locale}`;
+  }
+
+  #loadHistory(): Message[] {
+    try {
+      const raw = localStorage.getItem(this.#storageKey());
+      if (!raw) return [];
+      const parsed: unknown = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      // Only trust entries that look right. Anything else has been tampered
+      // with or comes from an older format, so drop it rather than crash.
+      return parsed.filter(
+        (m): m is Message =>
+          typeof m === 'object' &&
+          m !== null &&
+          (m.role === 'user' || m.role === 'assistant') &&
+          typeof m.content === 'string',
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  #saveHistory() {
+    try {
+      localStorage.setItem(this.#storageKey(), JSON.stringify(this.#messages));
+    } catch {
+      // Private mode or quota full. Chat keeps working in memory; refresh
+      // would lose it, but that's better than blocking the user. Surface a
+      // one-time notice so the loss isn't silent.
+      this.#notice.hidden = false;
+    }
+  }
+
+  #render() {
+    this.#log.replaceChildren();
+    for (const message of this.#messages) {
+      this.#log.append(this.#renderMessage(message));
+    }
+    const hasMessages = this.#messages.length > 0;
+    this.#empty.hidden = hasMessages;
+    this.#clear.hidden = !hasMessages;
+    this.#updateContextDivider();
+    this.#scrollToBottom();
+  }
+
+  #updateContextDivider() {
+    this.#log.querySelector('.ai-chat__context-divider')?.remove();
+    const overflow = this.#log.children.length - HISTORY_CAP;
+    if (overflow <= 0) return;
+    const divider = document.createElement('li');
+    divider.className = 'ai-chat__context-divider';
+    divider.setAttribute('aria-hidden', 'true');
+    divider.textContent = this.dataset.contextDividerText ?? '';
+    this.#log.insertBefore(divider, this.#log.children[overflow]);
+  }
+
+  #renderMessage(message: Message): HTMLLIElement {
+    const item = document.createElement('li');
+    item.className = `ai-chat__message ai-chat__message--${message.role}`;
+    item.setAttribute('data-role', message.role);
+
+    const body = document.createElement('div');
+    body.className = 'ai-chat__body';
+    if (message.role === 'assistant') {
+      body.innerHTML = renderMarkdown(message.content);
+    } else {
+      body.textContent = message.content;
+    }
+    item.append(body);
+
+    if (message.sources && message.sources.length > 0) {
+      item.append(this.#renderSources(message.sources));
+    }
+
+    return item;
+  }
+
+  #renderSources(sources: Source[]): HTMLUListElement {
+    const list = document.createElement('ul');
+    list.className = 'ai-chat__sources';
+    for (const source of sources) {
+      const li = document.createElement('li');
+      const link = document.createElement('a');
+      link.href = source.url;
+      link.textContent = source.title;
+      li.append(link);
+      list.append(li);
+    }
+    return list;
+  }
+
+  #scrollToBottom() {
+    this.#log.scrollTop = this.#log.scrollHeight;
+  }
+
+  #handleSubmit = (event: Event) => {
+    event.preventDefault();
+    const content = this.#input.value.trim();
+    if (!content) return;
+    void this.#run(content);
+  };
+
+  #handleKeydown = (event: KeyboardEvent) => {
+    // Enter sends; Shift+Enter inserts a newline. Matches most chat UIs.
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      this.#form.requestSubmit();
+    }
+  };
+
+  #handleClear = () => {
+    this.#messages = [];
+    this.#saveHistory();
+    this.#render();
+    this.#input.focus();
+  };
+
+  async #run(userContent: string) {
+    this.#messages.push({ role: 'user', content: userContent });
+    this.#log.append(this.#renderMessage(this.#messages[this.#messages.length - 1]));
+    this.#input.value = '';
+    this.#empty.hidden = true;
+    this.#clear.hidden = false;
+    this.#saveHistory();
+
+    const placeholderIndex = this.#messages.length;
+    this.#messages.push({ role: 'assistant', content: '' });
+    const placeholderEl = this.#renderMessage(this.#messages[placeholderIndex]);
+    const placeholderBody = placeholderEl.querySelector('.ai-chat__body') as HTMLElement;
+    placeholderBody.textContent = this.dataset.thinkingText ?? '';
+    this.#log.append(placeholderEl);
+    this.#updateContextDivider();
+    this.#scrollToBottom();
+
+    this.#setBusy(true);
+
+    let answer = '';
+    const seenUrls = new Set<string>();
+    const sources: Source[] = [];
+
+    try {
+      const response = await fetch('/api/ai-chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: this.#messages
+            .slice(0, placeholderIndex)
+            .map(({ role, content }) => ({ role, content })),
+        }),
+      });
+      if (!response.ok || !response.body) {
+        throw new Error(`Request failed (${response.status})`);
+      }
+
+      let receivedFirst = false;
+      for await (const event of readSseEvents(response.body)) {
+        if (event.name === 'chunks') {
+          const newSources = parseChunks(event.data as RetrievedChunk[], seenUrls);
+          if (newSources.length > 0) {
+            sources.push(...newSources);
+            // Drop any old sources block, append the latest set.
+            placeholderEl.querySelector('.ai-chat__sources')?.remove();
+            placeholderEl.append(this.#renderSources(sources));
+          }
+        } else {
+          const delta = getDeltaContent(event);
+          if (delta) {
+            if (!receivedFirst) {
+              placeholderBody.textContent = '';
+              receivedFirst = true;
+            }
+            answer += delta;
+            placeholderBody.innerHTML = renderMarkdown(answer);
+            this.#scrollToBottom();
+          }
+        }
+      }
+
+      if (!answer) {
+        answer = this.dataset.emptyText ?? '';
+        placeholderBody.textContent = answer;
+      }
+
+      this.#messages[placeholderIndex] = { role: 'assistant', content: answer, sources };
+    } catch (error) {
+      console.error('ai-chat:', error);
+      placeholderBody.textContent = this.dataset.errorText ?? '';
+      // Drop the failed assistant turn from state so subsequent requests don't
+      // include an empty/garbage entry. The error bubble stays visible until
+      // the next interaction; on refresh it's gone with the rest of the
+      // unsaved state.
+      this.#messages.pop();
+    } finally {
+      this.#saveHistory();
+      this.#setBusy(false);
+      this.#input.focus();
+    }
+  }
+
+  #setBusy(busy: boolean) {
+    this.toggleAttribute('aria-busy', busy);
+    this.#submit.disabled = busy;
+    this.#input.disabled = busy;
+  }
+}
+
+customElements.define('ai-chat', AiChat);

--- a/src/components/AiSearch/AiSearch.astro
+++ b/src/components/AiSearch/AiSearch.astro
@@ -1,4 +1,6 @@
 ---
+import { t } from '~/lib/i18n';
+import { siteName } from '~/lib/seo';
 import { queryParamName } from '~/lib/search';
 
 /*
@@ -9,39 +11,39 @@ const inputId = 'ai-search-input';
 ---
 
 <ai-search
-  data-thinking-text="Thinking…"
-  data-empty-text="No answer found for that question."
-  data-error-text="Something went wrong. Please try again."
+  data-thinking-text={t('ask_thinking')}
+  data-empty-text={t('ask_empty')}
+  data-error-text={t('ask_error')}
 >
   <div class="ai-search__head">
-    <h1>Ask Head Start</h1>
+    <h1>{t('ask_on_site', { siteName: siteName() })}</h1>
     <p class="ai-search__intro">
-      Ask a question and get an answer drawn from this site's content.
+      {t('ask_intro')}
     </p>
     <form class="ai-search__form" role="search">
-      <label class="a11y-sr-only" for={inputId}>Ask a question</label>
+      <label class="a11y-sr-only" for={inputId}>{t('ask_label')}</label>
       <input
         class="ai-search__input"
         id={inputId}
         name={queryParamName}
         type="search"
-        placeholder="Ask a question about this site…"
+        placeholder={t('ask_placeholder')}
         autocomplete="off"
         required
         data-input
       />
-      <button type="submit" data-submit>Ask</button>
+      <button type="submit" data-submit>{t('ask_submit')}</button>
     </form>
   </div>
 
   <div class="ai-search__result" data-result hidden>
     <article>
-      <h2>Answer</h2>
+      <h2>{t('ask_answer')}</h2>
       <p class="ai-search__status" data-status aria-live="polite"></p>
       <div class="ai-search__text" data-answer></div>
     </article>
     <aside data-sources-wrap hidden>
-      <h2>Sources</h2>
+      <h2>{t('ask_sources')}</h2>
       <ul class="ai-search__sources" data-sources></ul>
     </aside>
   </div>

--- a/src/components/AiSearch/AiSearch.astro
+++ b/src/components/AiSearch/AiSearch.astro
@@ -80,11 +80,6 @@ const inputId = 'ai-search-input';
     background: #f5f5f5;
     font-size: 0.8em;
   }
-  ai-search .ai-search__sources {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
   ai-search .ai-search__sources li {
     margin-block-end: 0.75rem;
   }

--- a/src/components/AiSearch/AiSearch.astro
+++ b/src/components/AiSearch/AiSearch.astro
@@ -1,0 +1,96 @@
+---
+import { queryParamName } from '~/lib/search';
+
+/*
+ * <ai-search> component: the question box, the streamed answer, and its sources.
+ */
+
+const inputId = 'ai-search-input';
+---
+
+<ai-search
+  data-thinking-text="Thinking…"
+  data-empty-text="No answer found for that question."
+  data-error-text="Something went wrong. Please try again."
+>
+  <div class="ai-search__head">
+    <h1>Ask Head Start</h1>
+    <p class="ai-search__intro">
+      Ask a question and get an answer drawn from this site's content.
+    </p>
+    <form class="ai-search__form" role="search">
+      <label class="a11y-sr-only" for={inputId}>Ask a question</label>
+      <input
+        class="ai-search__input"
+        id={inputId}
+        name={queryParamName}
+        type="search"
+        placeholder="Ask a question about this site…"
+        autocomplete="off"
+        required
+        data-input
+      />
+      <button type="submit" data-submit>Ask</button>
+    </form>
+  </div>
+
+  <div class="ai-search__result" data-result hidden>
+    <article>
+      <h2>Answer</h2>
+      <p class="ai-search__status" data-status aria-live="polite"></p>
+      <div class="ai-search__text" data-answer></div>
+    </article>
+    <aside data-sources-wrap hidden>
+      <h2>Sources</h2>
+      <ul class="ai-search__sources" data-sources></ul>
+    </aside>
+  </div>
+</ai-search>
+
+<script src="./AiSearch.client.ts"></script>
+
+<style is:global>
+  ai-search {
+    display: block;
+  }
+  ai-search .ai-search__intro {
+    margin-block: 0.25rem 1.5rem;
+  }
+  ai-search .ai-search__form {
+    display: flex;
+    gap: 0.5rem;
+  }
+  ai-search .ai-search__input {
+    flex: 1;
+  }
+  ai-search .ai-search__result {
+    margin-block-start: 1.5rem;
+  }
+  ai-search [data-sources-wrap] {
+    margin-block-start: 1.5rem;
+  }
+  ai-search .ai-search__status:empty {
+    display: none;
+  }
+  ai-search .ai-search__text > :first-child {
+    margin-block-start: 0;
+  }
+  ai-search .ai-search__text pre {
+    padding: 0.75rem;
+    background: #f5f5f5;
+    font-size: 0.8em;
+  }
+  ai-search .ai-search__sources {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  ai-search .ai-search__sources li {
+    margin-block-end: 0.75rem;
+  }
+  ai-search .ai-search__sources span {
+    display: block;
+    font-size: 0.7em;
+    word-break: break-all;
+  }
+</style>

--- a/src/components/AiSearch/AiSearch.astro
+++ b/src/components/AiSearch/AiSearch.astro
@@ -82,6 +82,7 @@ const inputId = 'ai-search-input';
     background: #f5f5f5;
     font-size: 0.8em;
   }
+
   ai-search .ai-search__sources li {
     margin-block-end: 0.75rem;
   }

--- a/src/components/AiSearch/AiSearch.astro
+++ b/src/components/AiSearch/AiSearch.astro
@@ -11,39 +11,39 @@ const inputId = 'ai-search-input';
 ---
 
 <ai-search
-  data-thinking-text={t('ask_thinking')}
-  data-empty-text={t('ask_empty')}
-  data-error-text={t('ask_error')}
+  data-thinking-text={t('ask_ai_thinking')}
+  data-empty-text={t('ask_ai_empty')}
+  data-error-text={t('ask_ai_error')}
 >
   <div class="ai-search__head">
-    <h1>{t('ask_on_site', { siteName: siteName() })}</h1>
+    <h1>{t('ask_ai_on_site', { siteName: siteName() })}</h1>
     <p class="ai-search__intro">
-      {t('ask_intro')}
+      {t('ask_ai_intro')}
     </p>
     <form class="ai-search__form" role="search">
-      <label class="a11y-sr-only" for={inputId}>{t('ask_label')}</label>
+      <label class="a11y-sr-only" for={inputId}>{t('ask_ai_label')}</label>
       <input
         class="ai-search__input"
         id={inputId}
         name={queryParamName}
         type="search"
-        placeholder={t('ask_placeholder')}
+        placeholder={t('ask_ai_placeholder')}
         autocomplete="off"
         required
         data-input
       />
-      <button type="submit" data-submit>{t('ask_submit')}</button>
+      <button type="submit" data-submit>{t('ask_ai_submit')}</button>
     </form>
   </div>
 
   <div class="ai-search__result" data-result hidden>
     <article>
-      <h2>{t('ask_answer')}</h2>
+      <h2>{t('ask_ai_answer')}</h2>
       <p class="ai-search__status" data-status aria-live="polite"></p>
       <div class="ai-search__text" data-answer></div>
     </article>
     <aside data-sources-wrap hidden>
-      <h2>{t('ask_sources')}</h2>
+      <h2>{t('ask_ai_sources')}</h2>
       <ul class="ai-search__sources" data-sources></ul>
     </aside>
   </div>

--- a/src/components/AiSearch/AiSearch.client.ts
+++ b/src/components/AiSearch/AiSearch.client.ts
@@ -47,42 +47,45 @@ async function* readSseEvents(body: ReadableStream<Uint8Array>): AsyncGenerator<
 }
 
 class AiSearch extends HTMLElement {
-  #form: HTMLFormElement | null = null;
-  #input: HTMLInputElement | null = null;
-  #submit: HTMLButtonElement | null = null;
-  #result: HTMLElement | null = null;
-  #status: HTMLElement | null = null;
-  #answer: HTMLElement | null = null;
-  #sourcesWrap: HTMLElement | null = null;
-  #sources: HTMLElement | null = null;
+  #form: HTMLFormElement;
+  #input: HTMLInputElement;
+  #submit: HTMLButtonElement;
+  #result: HTMLElement;
+  #status: HTMLElement;
+  #answer: HTMLElement;
+  #sourcesWrap: HTMLElement;
+  #sources: HTMLElement;
+
+  constructor() {
+    super();
+    this.#form = this.querySelector('form') as HTMLFormElement;
+    this.#input = this.querySelector('[data-input]') as HTMLInputElement;
+    this.#submit = this.querySelector('[data-submit]') as HTMLButtonElement;
+    this.#result = this.querySelector('[data-result]') as HTMLElement;
+    this.#status = this.querySelector('[data-status]') as HTMLElement;
+    this.#answer = this.querySelector('[data-answer]') as HTMLElement;
+    this.#sourcesWrap = this.querySelector('[data-sources-wrap]') as HTMLElement;
+    this.#sources = this.querySelector('[data-sources]') as HTMLElement;
+  }
 
   connectedCallback() {
-    this.#form = this.querySelector('form');
-    this.#input = this.querySelector('[data-input]');
-    this.#submit = this.querySelector('[data-submit]');
-    this.#result = this.querySelector('[data-result]');
-    this.#status = this.querySelector('[data-status]');
-    this.#answer = this.querySelector('[data-answer]');
-    this.#sourcesWrap = this.querySelector('[data-sources-wrap]');
-    this.#sources = this.querySelector('[data-sources]');
-
-    this.#form?.addEventListener('submit', this.#handleSubmit);
+    this.#form.addEventListener('submit', this.#handleSubmit);
 
     // If the page was opened with ?query= in the URL, run that search straight away.
     const initial = new URL(location.href).searchParams.get('query')?.trim();
-    if (initial && this.#input) {
+    if (initial) {
       this.#input.value = initial;
       void this.#run(initial);
     }
   }
 
   disconnectedCallback() {
-    this.#form?.removeEventListener('submit', this.#handleSubmit);
+    this.#form.removeEventListener('submit', this.#handleSubmit);
   }
 
   #handleSubmit = (event: Event) => {
     event.preventDefault();
-    const query = this.#input?.value.trim();
+    const query = this.#input.value.trim();
     if (!query) return;
 
     const url = new URL(location.href);
@@ -93,9 +96,6 @@ class AiSearch extends HTMLElement {
   };
 
   async #run(query: string) {
-    if (!this.#result || !this.#status || !this.#answer || !this.#sources || !this.#sourcesWrap) {
-      return;
-    }
     this.#result.hidden = false;
     this.#setBusy(true);
     this.#status.textContent = this.dataset.thinkingText ?? '';
@@ -147,7 +147,6 @@ class AiSearch extends HTMLElement {
   }
 
   #addSource(title: string, url: string) {
-    if (!this.#sources || !this.#sourcesWrap) return;
     const link = document.createElement('a');
     link.href = url;
     const name = document.createElement('strong');
@@ -163,8 +162,8 @@ class AiSearch extends HTMLElement {
 
   #setBusy(busy: boolean) {
     this.toggleAttribute('aria-busy', busy);
-    if (this.#submit) this.#submit.disabled = busy;
-    if (this.#input) this.#input.disabled = busy;
+    this.#submit.disabled = busy;
+    this.#input.disabled = busy;
   }
 }
 

--- a/src/components/AiSearch/AiSearch.client.ts
+++ b/src/components/AiSearch/AiSearch.client.ts
@@ -1,0 +1,171 @@
+import { marked } from 'marked';
+import { parseFrontmatter } from '~/lib/frontmatter';
+
+/*
+ * <ai-search> custom element. Sends the question to /api/ai-search, then shows
+ * the answer and its sources as they stream back.
+ *
+ * The response arrives as a stream: first a `chunks` event listing the source
+ * pages, then the answer text in small pieces.
+ */
+
+type SseEvent = { name: string; data: unknown };
+type RetrievedChunk = { text?: string };
+type CompletionChunk = { choices?: { delta?: { content?: string } }[] };
+
+async function* readSseEvents(body: ReadableStream<Uint8Array>): AsyncGenerator<SseEvent> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    let boundary = buffer.indexOf('\n\n');
+    while (boundary !== -1) {
+      const block = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      boundary = buffer.indexOf('\n\n');
+
+      let name = 'message';
+      let data = '';
+      for (const line of block.split('\n')) {
+        if (line.startsWith('event:')) name = line.slice(6).trim();
+        else if (line.startsWith('data:')) data += line.slice(5).replace(/^ /, '');
+      }
+      if (data === '[DONE]') return;
+      if (!data) continue;
+      try {
+        yield { name, data: JSON.parse(data) };
+      } catch {
+        // Skip anything that isn't valid JSON, like keep-alive pings.
+      }
+    }
+  }
+}
+
+class AiSearch extends HTMLElement {
+  #form: HTMLFormElement | null = null;
+  #input: HTMLInputElement | null = null;
+  #submit: HTMLButtonElement | null = null;
+  #result: HTMLElement | null = null;
+  #status: HTMLElement | null = null;
+  #answer: HTMLElement | null = null;
+  #sourcesWrap: HTMLElement | null = null;
+  #sources: HTMLElement | null = null;
+
+  connectedCallback() {
+    this.#form = this.querySelector('form');
+    this.#input = this.querySelector('[data-input]');
+    this.#submit = this.querySelector('[data-submit]');
+    this.#result = this.querySelector('[data-result]');
+    this.#status = this.querySelector('[data-status]');
+    this.#answer = this.querySelector('[data-answer]');
+    this.#sourcesWrap = this.querySelector('[data-sources-wrap]');
+    this.#sources = this.querySelector('[data-sources]');
+
+    this.#form?.addEventListener('submit', this.#handleSubmit);
+
+    // If the page was opened with ?query= in the URL, run that search straight away.
+    const initial = new URL(location.href).searchParams.get('query')?.trim();
+    if (initial && this.#input) {
+      this.#input.value = initial;
+      void this.#run(initial);
+    }
+  }
+
+  disconnectedCallback() {
+    this.#form?.removeEventListener('submit', this.#handleSubmit);
+  }
+
+  #handleSubmit = (event: Event) => {
+    event.preventDefault();
+    const query = this.#input?.value.trim();
+    if (!query) return;
+
+    const url = new URL(location.href);
+    url.searchParams.set('query', query);
+    history.replaceState(null, '', url);
+
+    void this.#run(query);
+  };
+
+  async #run(query: string) {
+    if (!this.#result || !this.#status || !this.#answer || !this.#sources || !this.#sourcesWrap) {
+      return;
+    }
+    this.#result.hidden = false;
+    this.#setBusy(true);
+    this.#status.textContent = this.dataset.thinkingText ?? '';
+    this.#answer.textContent = '';
+    this.#sources.replaceChildren();
+    this.#sourcesWrap.hidden = true;
+
+    let answer = '';
+    const seenUrls = new Set<string>();
+
+    try {
+      const response = await fetch('/api/ai-search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query }),
+      });
+      if (!response.ok || !response.body) {
+        throw new Error(`Request failed (${response.status})`);
+      }
+
+      for await (const event of readSseEvents(response.body)) {
+        if (event.name === 'chunks') {
+          for (const chunk of event.data as RetrievedChunk[]) {
+            const { url, title } = parseFrontmatter(chunk.text ?? '');
+            if (url && !seenUrls.has(url)) {
+              seenUrls.add(url);
+              this.#addSource(title || url, url);
+            }
+          }
+        } else {
+          const delta = (event.data as CompletionChunk).choices?.[0]?.delta?.content;
+          if (delta) {
+            answer += delta;
+            // Re-render the whole answer each time, so markdown like code
+            // blocks and lists still formats correctly as more text arrives.
+            this.#answer.innerHTML = marked.parse(answer) as string;
+            this.#status.textContent = '';
+          }
+        }
+      }
+
+      if (!answer) this.#status.textContent = this.dataset.emptyText ?? '';
+    } catch (error) {
+      console.error('ai-search:', error);
+      this.#status.textContent = this.dataset.errorText ?? '';
+    } finally {
+      this.#setBusy(false);
+    }
+  }
+
+  #addSource(title: string, url: string) {
+    if (!this.#sources || !this.#sourcesWrap) return;
+    const link = document.createElement('a');
+    link.href = url;
+    const name = document.createElement('strong');
+    name.textContent = title;
+    const location = document.createElement('span');
+    location.textContent = url;
+    link.append(name, location);
+    const item = document.createElement('li');
+    item.append(link);
+    this.#sources.append(item);
+    this.#sourcesWrap.hidden = false;
+  }
+
+  #setBusy(busy: boolean) {
+    this.toggleAttribute('aria-busy', busy);
+    if (this.#submit) this.#submit.disabled = busy;
+    if (this.#input) this.#input.disabled = busy;
+  }
+}
+
+customElements.define('ai-search', AiSearch);

--- a/src/components/AiSearch/AiSearch.client.ts
+++ b/src/components/AiSearch/AiSearch.client.ts
@@ -1,5 +1,10 @@
-import { marked } from 'marked';
-import { parseFrontmatter } from '~/lib/frontmatter';
+import {
+  readSseEvents,
+  parseChunks,
+  getDeltaContent,
+  renderMarkdown,
+  type RetrievedChunk,
+} from '~/lib/ai-stream';
 
 /*
  * <ai-search> custom element. Sends the question to /api/ai-search, then shows
@@ -8,43 +13,6 @@ import { parseFrontmatter } from '~/lib/frontmatter';
  * The response arrives as a stream: first a `chunks` event listing the source
  * pages, then the answer text in small pieces.
  */
-
-type SseEvent = { name: string; data: unknown };
-type RetrievedChunk = { text?: string };
-type CompletionChunk = { choices?: { delta?: { content?: string } }[] };
-
-async function* readSseEvents(body: ReadableStream<Uint8Array>): AsyncGenerator<SseEvent> {
-  const reader = body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
-
-    let boundary = buffer.indexOf('\n\n');
-    while (boundary !== -1) {
-      const block = buffer.slice(0, boundary);
-      buffer = buffer.slice(boundary + 2);
-      boundary = buffer.indexOf('\n\n');
-
-      let name = 'message';
-      let data = '';
-      for (const line of block.split('\n')) {
-        if (line.startsWith('event:')) name = line.slice(6).trim();
-        else if (line.startsWith('data:')) data += line.slice(5).replace(/^ /, '');
-      }
-      if (data === '[DONE]') return;
-      if (!data) continue;
-      try {
-        yield { name, data: JSON.parse(data) };
-      } catch {
-        // Skip anything that isn't valid JSON, like keep-alive pings.
-      }
-    }
-  }
-}
 
 class AiSearch extends HTMLElement {
   #form: HTMLFormElement;
@@ -118,20 +86,16 @@ class AiSearch extends HTMLElement {
 
       for await (const event of readSseEvents(response.body)) {
         if (event.name === 'chunks') {
-          for (const chunk of event.data as RetrievedChunk[]) {
-            const { url, title } = parseFrontmatter(chunk.text ?? '');
-            if (url && !seenUrls.has(url)) {
-              seenUrls.add(url);
-              this.#addSource(title || url, url);
-            }
+          for (const source of parseChunks(event.data as RetrievedChunk[], seenUrls)) {
+            this.#addSource(source.title, source.url);
           }
         } else {
-          const delta = (event.data as CompletionChunk).choices?.[0]?.delta?.content;
+          const delta = getDeltaContent(event);
           if (delta) {
             answer += delta;
             // Re-render the whole answer each time, so markdown like code
             // blocks and lists still formats correctly as more text arrives.
-            this.#answer.innerHTML = marked.parse(answer) as string;
+            this.#answer.innerHTML = renderMarkdown(answer);
             this.#status.textContent = '';
           }
         }

--- a/src/components/AskLink/AskLink.astro
+++ b/src/components/AskLink/AskLink.astro
@@ -1,7 +1,8 @@
 ---
 import { getAskPathname } from '~/lib/ai-search';
+import { t } from '~/lib/i18n';
 
 const askUrl = getAskPathname();
 ---
 
-<a rel="search" href={askUrl}>Ask AI</a>
+<a rel="search" href={askUrl}>{t('ask')}</a>

--- a/src/components/AskLink/AskLink.astro
+++ b/src/components/AskLink/AskLink.astro
@@ -3,6 +3,7 @@ import { getAskPathname } from '~/lib/ai-search';
 import { t } from '~/lib/i18n';
 
 const askUrl = getAskPathname();
+const label = t('ask');
 ---
 
-<a rel="search" href={askUrl}>{t('ask')}</a>
+{label && <a rel="search" href={askUrl}>{label}</a>}

--- a/src/components/AskLink/AskLink.astro
+++ b/src/components/AskLink/AskLink.astro
@@ -1,7 +1,7 @@
 ---
-import { getLocale } from '~/lib/i18n';
+import { getAskPathname } from '~/lib/ai-search';
 
-const askUrl = `/${getLocale()}/ask/`;
+const askUrl = getAskPathname();
 ---
 
 <a rel="search" href={askUrl}>Ask AI</a>

--- a/src/components/AskLink/AskLink.astro
+++ b/src/components/AskLink/AskLink.astro
@@ -1,0 +1,7 @@
+---
+import { getLocale } from '~/lib/i18n';
+
+const askUrl = `/${getLocale()}/ask/`;
+---
+
+<a rel="search" href={askUrl}>Ask AI</a>

--- a/src/components/AskLink/AskLink.astro
+++ b/src/components/AskLink/AskLink.astro
@@ -3,7 +3,7 @@ import { getAskPathname } from '~/lib/ai-search';
 import { t } from '~/lib/i18n';
 
 const askUrl = getAskPathname();
-const label = t('ask');
+const label = t('ask_ai');
 ---
 
 {label && <a rel="search" href={askUrl}>{label}</a>}

--- a/src/components/ChatLink/ChatLink.astro
+++ b/src/components/ChatLink/ChatLink.astro
@@ -1,0 +1,8 @@
+---
+import { getLocale, t } from '~/lib/i18n';
+
+const chatUrl = `/${getLocale()}/chat/`;
+const label = t('chat');
+---
+
+{label && <a href={chatUrl}>{label}</a>}

--- a/src/layouts/AppHeader/AppHeader.astro
+++ b/src/layouts/AppHeader/AppHeader.astro
@@ -7,13 +7,14 @@ import AppMenu from '~/layouts/AppMenu/AppMenu.astro';
 interface Props {
   menuItems: AppMenuFragment['menuItems'];
   pageUrls: PageUrl[];
+  allowAiBots: boolean;
 }
-const { menuItems, pageUrls } = Astro.props;
+const { menuItems, pageUrls, allowAiBots } = Astro.props;
 ---
 
 <header>
   <AppLogo />
-  <AppMenu items={menuItems} {pageUrls} />
+  <AppMenu items={menuItems} {pageUrls} {allowAiBots} />
 </header>
 
 <style>

--- a/src/layouts/AppMenu/AppMenu.astro
+++ b/src/layouts/AppMenu/AppMenu.astro
@@ -4,6 +4,7 @@ import { t } from '~/lib/i18n';
 import type { PageUrl } from '~/lib/routing';
 import AppLogo from '~/components/AppLogo/AppLogo.astro';
 import AskLink from '~/components/AskLink/AskLink.astro';
+import ChatLink from '~/components/ChatLink/ChatLink.astro';
 import IconButton from '~/components/IconButton/IconButton.astro';
 import LocaleSelector from '~/components/LocaleSelector/LocaleSelector.astro';
 import SearchLink from '~/components/SearchLink/SearchLink.astro';
@@ -18,6 +19,7 @@ export interface Props {
 }
 const { items, pageUrls, allowAiBots } = Astro.props;
 const showAskLink = allowAiBots && Boolean(t('ask'));
+const showChatLink = allowAiBots && Boolean(t('chat'));
 ---
 
 <app-menu>
@@ -90,7 +92,14 @@ const showAskLink = allowAiBots && Boolean(t('ask'));
           </li>
         )
       }
-      <li class:list={['main-menu__item', !showAskLink && 'main-menu__item--last']} data-menu-item>
+      {
+        showChatLink && (
+          <li class:list={['main-menu__item', !showAskLink && 'main-menu__item--last']} data-menu-item>
+            <ChatLink />
+          </li>
+        )
+      }
+      <li class:list={['main-menu__item', !showAskLink && !showChatLink && 'main-menu__item--last']} data-menu-item>
         <SearchLink />
       </li>
     </UnstyledList>
@@ -140,6 +149,7 @@ const showAskLink = allowAiBots && Boolean(t('ask'));
           })
         }
         {showAskLink && <li><AskLink /></li>}
+        {showChatLink && <li><ChatLink /></li>}
         <li><SearchLink /></li>
       </UnstyledList>
     </nav>

--- a/src/layouts/AppMenu/AppMenu.astro
+++ b/src/layouts/AppMenu/AppMenu.astro
@@ -14,8 +14,9 @@ import { getItemPopoverId } from './AppMenu';
 export interface Props {
   items: AppMenuFragment['menuItems'];
   pageUrls: PageUrl[];
+  allowAiBots: boolean;
 }
-const { items, pageUrls } = Astro.props;
+const { items, pageUrls, allowAiBots } = Astro.props;
 ---
 
 <app-menu>
@@ -81,10 +82,14 @@ const { items, pageUrls } = Astro.props;
           );
         })
       }
-      <li class="main-menu__item main-menu__item--last" data-menu-item>
-        <AskLink />
-      </li>
-      <li class="main-menu__item" data-menu-item>
+      {
+        allowAiBots && (
+          <li class="main-menu__item main-menu__item--last" data-menu-item>
+            <AskLink />
+          </li>
+        )
+      }
+      <li class:list={['main-menu__item', !allowAiBots && 'main-menu__item--last']} data-menu-item>
         <SearchLink />
       </li>
     </UnstyledList>
@@ -133,7 +138,7 @@ const { items, pageUrls } = Astro.props;
             );
           })
         }
-        <li><AskLink /></li>
+        {allowAiBots && <li><AskLink /></li>}
         <li><SearchLink /></li>
       </UnstyledList>
     </nav>

--- a/src/layouts/AppMenu/AppMenu.astro
+++ b/src/layouts/AppMenu/AppMenu.astro
@@ -3,6 +3,7 @@ import type { AppMenuFragment } from '~/lib/datocms/types';
 import { t } from '~/lib/i18n';
 import type { PageUrl } from '~/lib/routing';
 import AppLogo from '~/components/AppLogo/AppLogo.astro';
+import AskLink from '~/components/AskLink/AskLink.astro';
 import IconButton from '~/components/IconButton/IconButton.astro';
 import LocaleSelector from '~/components/LocaleSelector/LocaleSelector.astro';
 import SearchLink from '~/components/SearchLink/SearchLink.astro';
@@ -81,6 +82,9 @@ const { items, pageUrls } = Astro.props;
         })
       }
       <li class="main-menu__item main-menu__item--last" data-menu-item>
+        <AskLink />
+      </li>
+      <li class="main-menu__item" data-menu-item>
         <SearchLink />
       </li>
     </UnstyledList>
@@ -129,6 +133,7 @@ const { items, pageUrls } = Astro.props;
             );
           })
         }
+        <li><AskLink /></li>
         <li><SearchLink /></li>
       </UnstyledList>
     </nav>

--- a/src/layouts/AppMenu/AppMenu.astro
+++ b/src/layouts/AppMenu/AppMenu.astro
@@ -17,6 +17,7 @@ export interface Props {
   allowAiBots: boolean;
 }
 const { items, pageUrls, allowAiBots } = Astro.props;
+const showAskLink = allowAiBots && Boolean(t('ask'));
 ---
 
 <app-menu>
@@ -83,13 +84,13 @@ const { items, pageUrls, allowAiBots } = Astro.props;
         })
       }
       {
-        allowAiBots && (
+        showAskLink && (
           <li class="main-menu__item main-menu__item--last" data-menu-item>
             <AskLink />
           </li>
         )
       }
-      <li class:list={['main-menu__item', !allowAiBots && 'main-menu__item--last']} data-menu-item>
+      <li class:list={['main-menu__item', !showAskLink && 'main-menu__item--last']} data-menu-item>
         <SearchLink />
       </li>
     </UnstyledList>
@@ -138,7 +139,7 @@ const { items, pageUrls, allowAiBots } = Astro.props;
             );
           })
         }
-        {allowAiBots && <li><AskLink /></li>}
+        {showAskLink && <li><AskLink /></li>}
         <li><SearchLink /></li>
       </UnstyledList>
     </nav>

--- a/src/layouts/AppMenu/AppMenu.astro
+++ b/src/layouts/AppMenu/AppMenu.astro
@@ -17,7 +17,7 @@ export interface Props {
   allowAiBots: boolean;
 }
 const { items, pageUrls, allowAiBots } = Astro.props;
-const showAskLink = allowAiBots && Boolean(t('ask'));
+const showAskLink = allowAiBots && Boolean(t('ask_ai'));
 ---
 
 <app-menu>

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -36,7 +36,7 @@ const mainContentId = 'content';
 const menuItems = data.app?.menuItems ?? [];
 
 const { isPreview, editModeOn } = Astro.locals;
-const allowAiBots = isAllowAiBots(isPreview);
+const allowAiBots = await isAllowAiBots(isPreview);
 const prompt = app.openPageInLlmPrompt || '';
 const llmOptions = app.openPageInLlmOption ?? [];
 ---

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -16,7 +16,7 @@ import OpenInLlm from '~/components/OpenInLlm/OpenInLlm.astro';
 import AppHeader from './AppHeader/AppHeader.astro';
 import PerfHead from './PerfHead/PerfHead.astro';
 import SeoHead from './SeoHead/SeoHead.astro';
-import { getApp } from '~/lib/app';
+import { getApp, isAllowAiBots } from '~/lib/app';
 import '~/assets/a11y.css';
 
 interface Props {
@@ -36,9 +36,9 @@ const mainContentId = 'content';
 const menuItems = data.app?.menuItems ?? [];
 
 const { isPreview, editModeOn } = Astro.locals;
-const allowAiBots = !app.noIndex && !isPreview && Boolean(app.allowAiBots);
-const prompt = data.app?.openPageInLlmPrompt ?? app.openPageInLlmPrompt ?? '';
-const llmOptions = data.app?.openPageInLlmOption ?? app.openPageInLlmOption ?? [];
+const allowAiBots = isAllowAiBots(isPreview);
+const prompt = app.openPageInLlmPrompt || '';
+const llmOptions = app.openPageInLlmOption ?? [];
 ---
 
 <!doctype html>
@@ -61,7 +61,7 @@ const llmOptions = data.app?.openPageInLlmOption ?? app.openPageInLlmOption ?? [
     <PreviewModeProvider>
       <SkipLink targetId={mainContentId} />
       <div {...datocmsNoIndex}>
-        <AppHeader {menuItems} {pageUrls} />
+        <AppHeader {menuItems} {pageUrls} {allowAiBots} />
       </div>
       {
         (breadcrumbs.length > 0 || allowAiBots) && (

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -16,7 +16,7 @@ import OpenInLlm from '~/components/OpenInLlm/OpenInLlm.astro';
 import AppHeader from './AppHeader/AppHeader.astro';
 import PerfHead from './PerfHead/PerfHead.astro';
 import SeoHead from './SeoHead/SeoHead.astro';
-import { getApp, isAllowAiBots } from '~/lib/app';
+import { isAiBotsAllowed } from '~/lib/app';
 import '~/assets/a11y.css';
 
 interface Props {
@@ -26,7 +26,6 @@ interface Props {
 }
 
 const { locale = defaultLocale } = Astro.params as { locale?: SiteLocale };
-const app = await getApp();
 const data = await datocmsRequest<DefaultLayoutQuery>({
   query,
   variables: { locale },
@@ -36,9 +35,9 @@ const mainContentId = 'content';
 const menuItems = data.app?.menuItems ?? [];
 
 const { isPreview, editModeOn } = Astro.locals;
-const allowAiBots = await isAllowAiBots(isPreview);
-const prompt = app.openPageInLlmPrompt || '';
-const llmOptions = app.openPageInLlmOption ?? [];
+const allowAiBots = await isAiBotsAllowed(isPreview);
+const prompt = data.app?.openPageInLlmPrompt || '';
+const llmOptions = data.app?.openPageInLlmOption ?? [];
 ---
 
 <!doctype html>

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -16,7 +16,7 @@ import OpenInLlm from '~/components/OpenInLlm/OpenInLlm.astro';
 import AppHeader from './AppHeader/AppHeader.astro';
 import PerfHead from './PerfHead/PerfHead.astro';
 import SeoHead from './SeoHead/SeoHead.astro';
-import { isAiBotsAllowed } from '~/lib/app';
+import { isAllowAiBots } from '~/lib/app';
 import '~/assets/a11y.css';
 
 interface Props {
@@ -35,7 +35,7 @@ const mainContentId = 'content';
 const menuItems = data.app?.menuItems ?? [];
 
 const { isPreview, editModeOn } = Astro.locals;
-const allowAiBots = await isAiBotsAllowed(isPreview);
+const allowAiBots = await isAllowAiBots(isPreview);
 const prompt = data.app?.openPageInLlmPrompt || '';
 const llmOptions = data.app?.openPageInLlmOption ?? [];
 ---

--- a/src/lib/ai-search/index.test.ts
+++ b/src/lib/ai-search/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+import { getAskPathname } from '~/lib/ai-search';
+
+describe('ai-search', () => {
+  test('"getAskPathname" should return correct ask pathname for a specific locale', () => {
+    expect(getAskPathname('en')).toBe('/en/ask/');
+    expect(getAskPathname('nl')).toBe('/nl/ask/');
+  });
+});

--- a/src/lib/ai-search/index.test.ts
+++ b/src/lib/ai-search/index.test.ts
@@ -1,9 +1,0 @@
-import { describe, expect, test } from 'vitest';
-import { getAskPathname } from '~/lib/ai-search';
-
-describe('ai-search', () => {
-  test('"getAskPathname" should return correct ask pathname for a specific locale', () => {
-    expect(getAskPathname('en')).toBe('/en/ask/');
-    expect(getAskPathname('nl')).toBe('/nl/ask/');
-  });
-});

--- a/src/lib/ai-search/index.ts
+++ b/src/lib/ai-search/index.ts
@@ -1,0 +1,4 @@
+import type { SiteLocale } from '~/lib/datocms/types';
+import { getLocale } from '~/lib/i18n';
+
+export const getAskPathname = (locale: SiteLocale = getLocale()) => `/${locale}/ask/`;

--- a/src/lib/ai-search/index.ts
+++ b/src/lib/ai-search/index.ts
@@ -1,4 +1,4 @@
-import type { SiteLocale } from '~/lib/datocms/types';
+import type { SiteLocale } from '~/lib/datocms/schema';
 import { getLocale } from '~/lib/i18n';
 
 export const getAskPathname = (locale: SiteLocale = getLocale()) => `/${locale}/ask/`;

--- a/src/lib/ai-stream.test.ts
+++ b/src/lib/ai-stream.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from 'vitest';
+import {
+  getDeltaContent,
+  parseChunks,
+  readSseEvents,
+  renderMarkdown,
+  type SseEvent,
+} from '~/lib/ai-stream';
+
+/*
+ * Turn a list of string parts into a ReadableStream, each part delivered as its
+ * own chunk. This lets us assert that `readSseEvents` reassembles events that
+ * are split across read boundaries.
+ */
+function streamFrom(parts: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const part of parts) controller.enqueue(encoder.encode(part));
+      controller.close();
+    },
+  });
+}
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<SseEvent[]> {
+  const events: SseEvent[] = [];
+  for await (const event of readSseEvents(stream)) events.push(event);
+  return events;
+}
+
+describe('readSseEvents', () => {
+  test('parses a named event with JSON data', async () => {
+    const events = await collect(streamFrom(['event: chunks\ndata: {"a":1}\n\n']));
+    expect(events).toEqual([{ name: 'chunks', data: { a: 1 } }]);
+  });
+
+  test('defaults the event name to "message" when no event line is present', async () => {
+    const events = await collect(streamFrom(['data: {"a":1}\n\n']));
+    expect(events).toEqual([{ name: 'message', data: { a: 1 } }]);
+  });
+
+  test('reassembles an event split across read boundaries', async () => {
+    const events = await collect(streamFrom(['event: chu', 'nks\ndata: {"a', '":1}\n\n']));
+    expect(events).toEqual([{ name: 'chunks', data: { a: 1 } }]);
+  });
+
+  test('emits multiple events delivered in a single chunk', async () => {
+    const events = await collect(streamFrom(['data: {"a":1}\n\ndata: {"b":2}\n\n']));
+    expect(events).toEqual([
+      { name: 'message', data: { a: 1 } },
+      { name: 'message', data: { b: 2 } },
+    ]);
+  });
+
+  test('concatenates multiple data lines within one event', async () => {
+    const events = await collect(streamFrom(['data: {"a":\ndata: 1}\n\n']));
+    expect(events).toEqual([{ name: 'message', data: { a: 1 } }]);
+  });
+
+  test('stops at a [DONE] sentinel and ignores anything after it', async () => {
+    const events = await collect(streamFrom(['data: {"a":1}\n\ndata: [DONE]\n\ndata: {"b":2}\n\n']));
+    expect(events).toEqual([{ name: 'message', data: { a: 1 } }]);
+  });
+
+  test('skips blocks with no data line', async () => {
+    const events = await collect(streamFrom([': keep-alive\n\ndata: {"a":1}\n\n']));
+    expect(events).toEqual([{ name: 'message', data: { a: 1 } }]);
+  });
+
+  test('skips data that is not valid JSON', async () => {
+    const events = await collect(streamFrom(['data: not-json\n\ndata: {"a":1}\n\n']));
+    expect(events).toEqual([{ name: 'message', data: { a: 1 } }]);
+  });
+
+  test('ignores a trailing block without a terminating blank line', async () => {
+    const events = await collect(streamFrom(['data: {"a":1}\n\ndata: {"b":2}']));
+    expect(events).toEqual([{ name: 'message', data: { a: 1 } }]);
+  });
+});
+
+describe('parseChunks', () => {
+  const chunkFor = (url: string, title?: string) => ({
+    text: `---\n${title ? `title: "${title}"\n` : ''}url: "${url}"\n---\n\n`,
+  });
+
+  test('extracts url and title from chunk frontmatter', () => {
+    const sources = parseChunks([chunkFor('https://example.com/', 'Example')], new Set());
+    expect(sources).toEqual([{ url: 'https://example.com/', title: 'Example' }]);
+  });
+
+  test('falls back to the url as title when title is missing', () => {
+    const sources = parseChunks([chunkFor('https://example.com/')], new Set());
+    expect(sources).toEqual([{ url: 'https://example.com/', title: 'https://example.com/' }]);
+  });
+
+  test('de-dupes against the seen set and mutates it', () => {
+    const seen = new Set<string>();
+    const first = parseChunks([chunkFor('https://a.com/', 'A')], seen);
+    const second = parseChunks([chunkFor('https://a.com/', 'A')], seen);
+    expect(first).toHaveLength(1);
+    expect(second).toEqual([]);
+    expect(seen.has('https://a.com/')).toBe(true);
+  });
+
+  test('skips chunks without a url', () => {
+    expect(parseChunks([{ text: '# no frontmatter' }, { text: undefined }], new Set())).toEqual([]);
+  });
+
+  test.each([
+    'javascript:alert(1)',
+    'JavaScript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)',
+  ])('drops a source whose url has the unsafe scheme %j', (url) => {
+    const seen = new Set<string>();
+    expect(parseChunks([chunkFor(url, 'Evil')], seen)).toEqual([]);
+    expect(seen.has(url)).toBe(false);
+  });
+
+  test.each([
+    'https://example.com/',
+    'http://example.com/',
+    'mailto:x@example.com',
+    '/relative/path',
+  ])('keeps a source with the safe url %j', (url) => {
+    expect(parseChunks([chunkFor(url, 'Safe')], new Set())).toEqual([{ url, title: 'Safe' }]);
+  });
+});
+
+/*
+ * `renderMarkdown` output is assigned to `innerHTML`, so model output must not
+ * be able to inject executable HTML. These guard the sanitization contract.
+ */
+describe('renderMarkdown sanitization', () => {
+  test('escapes a literal <script> tag instead of emitting it', () => {
+    const html = renderMarkdown('<script>alert(1)</script>');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  test('escapes a literal img with an onerror handler', () => {
+    const html = renderMarkdown('<img src=x onerror=alert(1)>');
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img');
+  });
+
+  test('neutralizes a javascript: URL in a markdown link', () => {
+    const html = renderMarkdown('[click me](javascript:alert(1))');
+    expect(html).not.toContain('javascript:');
+    expect(html).toContain('href="#"');
+  });
+
+  test('neutralizes a javascript: URL in a markdown image', () => {
+    const html = renderMarkdown('![img](javascript:alert(1))');
+    expect(html).not.toContain('javascript:');
+    expect(html).toContain('src="#"');
+  });
+
+  test('does not emit a live URL for a scheme obfuscated with a control character', () => {
+    // marked declines to parse this as a link at all, so it stays inert text;
+    // either way the scheme must never become an href/src attribute value.
+    const html = renderMarkdown('[x](java\tscript:alert(1))');
+    expect(html).not.toContain('="java');
+  });
+
+  test('preserves safe http and relative links', () => {
+    expect(renderMarkdown('[a](https://example.com/)')).toContain('href="https://example.com/"');
+    expect(renderMarkdown('[b](/about)')).toContain('href="/about"');
+    expect(renderMarkdown('[c](mailto:x@example.com)')).toContain('href="mailto:x@example.com"');
+  });
+
+  test('renders ordinary markdown formatting', () => {
+    expect(renderMarkdown('normal **bold** text')).toContain('<strong>bold</strong>');
+  });
+});
+
+describe('getDeltaContent', () => {
+  test('returns the delta content of the first choice', () => {
+    const event: SseEvent = { name: 'message', data: { choices: [{ delta: { content: 'hi' } }] } };
+    expect(getDeltaContent(event)).toBe('hi');
+  });
+
+  test('returns undefined when there are no choices', () => {
+    expect(getDeltaContent({ name: 'message', data: {} })).toBeUndefined();
+  });
+
+  test('returns undefined when the delta has no content', () => {
+    expect(getDeltaContent({ name: 'message', data: { choices: [{ delta: {} }] } })).toBeUndefined();
+  });
+});

--- a/src/lib/ai-stream.ts
+++ b/src/lib/ai-stream.ts
@@ -1,0 +1,102 @@
+import { Marked } from 'marked';
+import { parseFrontmatter } from '~/lib/frontmatter';
+
+/*
+ * Shared helpers for consuming the SSE stream from `/api/ai-search` and
+ * `/api/ai-chat`. Both endpoints return the same shape: a `chunks` event
+ * listing the retrieved source pages, then OpenAI-style completion chunks
+ * with the answer text.
+ */
+
+export const HISTORY_CAP = 10;
+
+export type SseEvent = { name: string; data: unknown };
+export type RetrievedChunk = { text?: string };
+export type CompletionChunk = { choices?: { delta?: { content?: string } }[] };
+export type Source = { url: string; title: string };
+
+export async function* readSseEvents(
+  body: ReadableStream<Uint8Array>,
+): AsyncGenerator<SseEvent> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    let boundary = buffer.indexOf('\n\n');
+    while (boundary !== -1) {
+      const block = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      boundary = buffer.indexOf('\n\n');
+
+      let name = 'message';
+      let data = '';
+      for (const line of block.split('\n')) {
+        if (line.startsWith('event:')) name = line.slice(6).trim();
+        else if (line.startsWith('data:')) data += line.slice(5).replace(/^ /, '');
+      }
+      if (data === '[DONE]') return;
+      if (!data) continue;
+      try {
+        yield { name, data: JSON.parse(data) };
+      } catch {
+        // Skip anything that isn't valid JSON, like keep-alive pings.
+      }
+    }
+  }
+}
+
+const SAFE_URL = /^(https?:|mailto:|tel:|\/|#|\.)/i;
+
+function isSafeUrl(url: string): boolean {
+  return SAFE_URL.test(url.trim());
+}
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+/*
+ * Pull new sources out of a `chunks` event. Mutates `seen` so callers can
+ * de-dupe across the whole conversation, not just one event.
+ */
+export function parseChunks(chunks: RetrievedChunk[], seen: Set<string>): Source[] {
+  const sources: Source[] = [];
+  for (const chunk of chunks) {
+    const { url, title } = parseFrontmatter(chunk.text ?? '');
+    if (url && isSafeUrl(url) && !seen.has(url)) {
+      seen.add(url);
+      sources.push({ url, title: title || url });
+    }
+  }
+  return sources;
+}
+
+export function getDeltaContent(event: SseEvent): string | undefined {
+  return (event.data as CompletionChunk).choices?.[0]?.delta?.content;
+}
+
+const markdown = new Marked({
+  walkTokens(token) {
+    if ((token.type === 'link' || token.type === 'image') && !isSafeUrl(token.href)) {
+      token.href = '#';
+    }
+  },
+  renderer: {
+    html({ text }) {
+      return escapeHtml(text);
+    },
+  },
+});
+
+export function renderMarkdown(source: string): string {
+  return markdown.parse(source, { async: false });
+}

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -15,4 +15,9 @@ export async function getApp(): Promise<App> {
   return cache;
 }
 
+export const isAllowAiBots = async (isPreview = false) => {
+  const app = await getApp();
+  return !app.noIndex && !isPreview && Boolean(app.allowAiBots);
+};
+
 export default getApp;

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -15,7 +15,7 @@ export async function getApp(): Promise<App> {
   return cache;
 }
 
-export const isAiBotsAllowed = async (isPreview = false) => {
+export const isAllowAiBots = async (isPreview = false) => {
   const app = await getApp();
   return !app.noIndex && !isPreview && Boolean(app.allowAiBots);
 };

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -15,7 +15,7 @@ export async function getApp(): Promise<App> {
   return cache;
 }
 
-export const isAllowAiBots = async (isPreview = false) => {
+export const isAiBotsAllowed = async (isPreview = false) => {
   const app = await getApp();
   return !app.noIndex && !isPreview && Boolean(app.allowAiBots);
 };

--- a/src/pages/[locale]/ask/index.astro
+++ b/src/pages/[locale]/ask/index.astro
@@ -3,7 +3,7 @@ import { getAskPathname } from '~/lib/ai-search';
 import { isAllowAiBots } from '~/lib/app';
 import { locales, t } from '~/lib/i18n';
 import { noIndexTag, siteName, titleTag } from '~/lib/seo';
-import type { SiteLocale } from '~/lib/datocms/types';
+import type { SiteLocale } from '~/lib/datocms/schema';
 import type { Breadcrumb } from '~/lib/routing';
 import Layout from '~/layouts/Default.astro';
 import AiSearch from '~/components/AiSearch/AiSearch.astro';
@@ -12,7 +12,7 @@ export const prerender = false;
 
 const { locale } = Astro.params as { locale: SiteLocale };
 
-if (!isAllowAiBots(Astro.locals.isPreview)) {
+if (!(await isAllowAiBots(Astro.locals.isPreview))) {
   return Astro.rewrite(`/404/?locale=${locale}`);
 }
 

--- a/src/pages/[locale]/ask/index.astro
+++ b/src/pages/[locale]/ask/index.astro
@@ -1,0 +1,27 @@
+---
+import { locales } from '~/lib/i18n';
+import { noIndexTag, titleTag } from '~/lib/seo';
+import type { SiteLocale } from '~/lib/datocms/types';
+import type { Breadcrumb } from '~/lib/routing';
+import Layout from '~/layouts/Default.astro';
+import AiSearch from '~/components/AiSearch/AiSearch.astro';
+
+export const prerender = false;
+
+const { locale } = Astro.params as { locale: SiteLocale };
+
+// Hardcoded English for now; needs a DatoCMS translation entry to use t().
+const pageTitle = 'Ask AI';
+
+const getAskPathname = (locale: SiteLocale) => `/${locale}/ask/`;
+const pageUrls = locales.map((locale) => ({ locale, pathname: getAskPathname(locale) }));
+const breadcrumbs: Breadcrumb[] = [{ text: pageTitle, href: getAskPathname(locale) }];
+---
+
+<Layout
+  breadcrumbs={breadcrumbs}
+  pageUrls={pageUrls}
+  seoMetaTags={[noIndexTag, titleTag(pageTitle)]}
+>
+  <AiSearch />
+</Layout>

--- a/src/pages/[locale]/ask/index.astro
+++ b/src/pages/[locale]/ask/index.astro
@@ -1,4 +1,5 @@
 ---
+import { getAskPathname } from '~/lib/ai-search';
 import { locales } from '~/lib/i18n';
 import { noIndexTag, titleTag } from '~/lib/seo';
 import type { SiteLocale } from '~/lib/datocms/types';
@@ -12,7 +13,6 @@ const { locale } = Astro.params as { locale: SiteLocale };
 
 const pageTitle = 'Ask AI';
 
-const getAskPathname = (locale: SiteLocale) => `/${locale}/ask/`;
 const pageUrls = locales.map((locale) => ({ locale, pathname: getAskPathname(locale) }));
 const breadcrumbs: Breadcrumb[] = [{ text: pageTitle, href: getAskPathname(locale) }];
 ---

--- a/src/pages/[locale]/ask/index.astro
+++ b/src/pages/[locale]/ask/index.astro
@@ -1,8 +1,8 @@
 ---
 import { getAskPathname } from '~/lib/ai-search';
 import { isAllowAiBots } from '~/lib/app';
-import { locales } from '~/lib/i18n';
-import { noIndexTag, titleTag } from '~/lib/seo';
+import { locales, t } from '~/lib/i18n';
+import { noIndexTag, siteName, titleTag } from '~/lib/seo';
 import type { SiteLocale } from '~/lib/datocms/types';
 import type { Breadcrumb } from '~/lib/routing';
 import Layout from '~/layouts/Default.astro';
@@ -16,10 +16,10 @@ if (!isAllowAiBots(Astro.locals.isPreview)) {
   return Astro.rewrite(`/404/?locale=${locale}`);
 }
 
-const pageTitle = 'Ask AI';
+const pageTitle = t('ask_on_site', { siteName: siteName() });
 
 const pageUrls = locales.map((locale) => ({ locale, pathname: getAskPathname(locale) }));
-const breadcrumbs: Breadcrumb[] = [{ text: pageTitle, href: getAskPathname(locale) }];
+const breadcrumbs: Breadcrumb[] = [{ text: t('ask'), href: getAskPathname(locale) }];
 ---
 
 <Layout

--- a/src/pages/[locale]/ask/index.astro
+++ b/src/pages/[locale]/ask/index.astro
@@ -1,5 +1,6 @@
 ---
 import { getAskPathname } from '~/lib/ai-search';
+import { isAllowAiBots } from '~/lib/app';
 import { locales } from '~/lib/i18n';
 import { noIndexTag, titleTag } from '~/lib/seo';
 import type { SiteLocale } from '~/lib/datocms/types';
@@ -10,6 +11,10 @@ import AiSearch from '~/components/AiSearch/AiSearch.astro';
 export const prerender = false;
 
 const { locale } = Astro.params as { locale: SiteLocale };
+
+if (!isAllowAiBots(Astro.locals.isPreview)) {
+  return Astro.rewrite(`/404/?locale=${locale}`);
+}
 
 const pageTitle = 'Ask AI';
 

--- a/src/pages/[locale]/ask/index.astro
+++ b/src/pages/[locale]/ask/index.astro
@@ -10,7 +10,6 @@ export const prerender = false;
 
 const { locale } = Astro.params as { locale: SiteLocale };
 
-// Hardcoded English for now; needs a DatoCMS translation entry to use t().
 const pageTitle = 'Ask AI';
 
 const getAskPathname = (locale: SiteLocale) => `/${locale}/ask/`;

--- a/src/pages/[locale]/ask/index.astro
+++ b/src/pages/[locale]/ask/index.astro
@@ -16,10 +16,10 @@ if (!(await isAiBotsAllowed(Astro.locals.isPreview))) {
   return Astro.rewrite(`/404/?locale=${locale}`);
 }
 
-const pageTitle = t('ask_on_site', { siteName: siteName() });
+const pageTitle = t('ask_ai_on_site', { siteName: siteName() });
 
 const pageUrls = locales.map((locale) => ({ locale, pathname: getAskPathname(locale) }));
-const breadcrumbs: Breadcrumb[] = [{ text: t('ask'), href: getAskPathname(locale) }];
+const breadcrumbs: Breadcrumb[] = [{ text: t('ask_ai'), href: getAskPathname(locale) }];
 ---
 
 <Layout

--- a/src/pages/[locale]/ask/index.astro
+++ b/src/pages/[locale]/ask/index.astro
@@ -1,6 +1,6 @@
 ---
 import { getAskPathname } from '~/lib/ai-search';
-import { isAllowAiBots } from '~/lib/app';
+import { isAiBotsAllowed } from '~/lib/app';
 import { locales, t } from '~/lib/i18n';
 import { noIndexTag, siteName, titleTag } from '~/lib/seo';
 import type { SiteLocale } from '~/lib/datocms/schema';
@@ -12,7 +12,7 @@ export const prerender = false;
 
 const { locale } = Astro.params as { locale: SiteLocale };
 
-if (!(await isAllowAiBots(Astro.locals.isPreview))) {
+if (!(await isAiBotsAllowed(Astro.locals.isPreview))) {
   return Astro.rewrite(`/404/?locale=${locale}`);
 }
 

--- a/src/pages/[locale]/chat/index.astro
+++ b/src/pages/[locale]/chat/index.astro
@@ -1,12 +1,11 @@
 ---
-import { getAskPathname } from '~/lib/ai-search';
 import { isAllowAiBots } from '~/lib/app';
 import { locales, t } from '~/lib/i18n';
 import { noIndexTag, siteName, titleTag } from '~/lib/seo';
 import type { SiteLocale } from '~/lib/datocms/schema';
 import type { Breadcrumb } from '~/lib/routing';
 import Layout from '~/layouts/Default.astro';
-import AiSearch from '~/components/AiSearch/AiSearch.astro';
+import AiChat from '~/components/AiChat/AiChat.astro';
 
 export const prerender = false;
 
@@ -16,10 +15,11 @@ if (!(await isAllowAiBots(Astro.locals.isPreview))) {
   return Astro.rewrite(`/404/?locale=${locale}`);
 }
 
-const pageTitle = t('ask_on_site', { siteName: siteName() });
+const pageTitle = t('chat_on_site', { siteName: siteName() });
 
-const pageUrls = locales.map((locale) => ({ locale, pathname: getAskPathname(locale) }));
-const breadcrumbs: Breadcrumb[] = [{ text: pageTitle, href: getAskPathname(locale) }];
+const getChatPathname = (locale: SiteLocale) => `/${locale}/chat/`;
+const pageUrls = locales.map((locale) => ({ locale, pathname: getChatPathname(locale) }));
+const breadcrumbs: Breadcrumb[] = [{ text: t('chat'), href: getChatPathname(locale) }];
 ---
 
 <Layout
@@ -27,5 +27,5 @@ const breadcrumbs: Breadcrumb[] = [{ text: pageTitle, href: getAskPathname(local
   pageUrls={pageUrls}
   seoMetaTags={[noIndexTag, titleTag(pageTitle)]}
 >
-  <AiSearch />
+  <AiChat />
 </Layout>

--- a/src/pages/api/ai-chat.ts
+++ b/src/pages/api/ai-chat.ts
@@ -1,0 +1,114 @@
+import type { APIRoute } from 'astro';
+import {
+  CLOUDFLARE_ACCOUNT_ID,
+  CLOUDFLARE_AI_API_TOKEN,
+  CLOUDFLARE_AI_SEARCH_INSTANCE_NAME,
+} from 'astro:env/server';
+import { HISTORY_CAP } from '~/lib/ai-stream';
+
+export const prerender = false;
+
+type ChatRole = 'user' | 'assistant';
+type ChatMessage = { role: ChatRole; content: string };
+
+const jsonError = (message: string, status: number) =>
+  new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+  });
+
+type ChunkMeta = { url?: string; title?: string };
+type ChatCompletionResponse = {
+  choices?: { message?: { content?: string } }[];
+  // Non-streaming response keeps metadata under `item.metadata`; streaming SSE uses `item.attributes`.
+  chunks?: { item?: { metadata?: ChunkMeta; attributes?: ChunkMeta } }[];
+};
+
+const reshapeAsJson = (payload: ChatCompletionResponse) => {
+  const answer = payload.choices?.[0]?.message?.content ?? '';
+  const seen = new Set<string>();
+  const sources = (payload.chunks ?? []).flatMap((chunk) => {
+    const meta = chunk.item?.metadata ?? chunk.item?.attributes;
+    const url = meta?.url;
+    if (!url || seen.has(url)) return [];
+    seen.add(url);
+    return [{ url, title: meta?.title ?? url }];
+  });
+  return { answer, sources };
+};
+
+const isValidMessage = (message: unknown): message is ChatMessage => {
+  if (typeof message !== 'object' || message === null) return false;
+  const { role, content } = message as { role?: unknown; content?: unknown };
+  if (role !== 'user' && role !== 'assistant') return false;
+  return typeof content === 'string' && content.trim().length > 0;
+};
+
+// Cloudflare expects the first message to be from the user. If we trimmed off a
+// user turn and the slice now starts with assistant, drop messages until it
+// does. Otherwise the upstream call errors.
+const capHistory = (messages: ChatMessage[]) => {
+  let trimmed = messages.slice(-HISTORY_CAP);
+  while (trimmed.length > 0 && trimmed[0].role !== 'user') {
+    trimmed = trimmed.slice(1);
+  }
+  return trimmed;
+};
+
+export const POST: APIRoute = async ({ request, url }) => {
+  if (!CLOUDFLARE_ACCOUNT_ID || !CLOUDFLARE_AI_API_TOKEN || !CLOUDFLARE_AI_SEARCH_INSTANCE_NAME) {
+    return jsonError('AI Search is not configured on this deployment.', 503);
+  }
+
+  let body: { messages?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError('Invalid JSON body.', 400);
+  }
+
+  if (!Array.isArray(body.messages) || body.messages.length === 0) {
+    return jsonError('Missing \'messages\' array.', 400);
+  }
+  if (!body.messages.every(isValidMessage)) {
+    return jsonError('Each message needs role (\'user\' or \'assistant\') and non-empty content.', 400);
+  }
+
+  const messages = capHistory(body.messages as ChatMessage[]);
+  if (messages.length === 0 || messages[messages.length - 1].role !== 'user') {
+    return jsonError('Last message must be from \'user\'.', 400);
+  }
+
+  const wantsJson = url.searchParams.get('format') === 'json';
+
+  const upstream = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai-search/instances/${CLOUDFLARE_AI_SEARCH_INSTANCE_NAME}/chat/completions`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${CLOUDFLARE_AI_API_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ messages, stream: !wantsJson }),
+    },
+  );
+
+  if (wantsJson) {
+    if (!upstream.ok) {
+      return jsonError(`Upstream error (${upstream.status})`, upstream.status);
+    }
+    const payload = (await upstream.json()) as ChatCompletionResponse;
+    return new Response(JSON.stringify(reshapeAsJson(payload), null, 2), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+    });
+  }
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: {
+      'Content-Type': upstream.headers.get('Content-Type') ?? 'text/event-stream',
+      'Cache-Control': 'no-store',
+    },
+  });
+};


### PR DESCRIPTION
Depends on https://github.com/voorhoede/head-start/pull/379

Adds the "Ask AI" page so people can actually use the AI search we wired up in the previous PR. Type a question, get an answer with sources.

<img width="1471" height="991" alt="Screenshot 2026-05-27 at 09 21 26" src="https://github.com/user-attachments/assets/342f03f2-d239-4f43-8fae-7fdcbb40f6ca" />


## What's added

- A new **Ask AI** page at `/[locale]/ask/`. Question box at the top, answer streams in below as it's written, sources show up alongside it.
- An **Ask AI** link in the main nav, right next to Search. Same link in the mobile nav.
- The answer renders as proper markdown while it's still streaming, so code blocks and lists look right from the first chunk, not just when it finishes.
- You can share a question via URL: `/en/ask/?query=...` runs the search on page load, and submitting the form keeps the URL in sync. Good for linking people to "here's the answer I got".

## How to test

Check cloudfare preview link https://feat-ai-search-component.head-start.pages.dev/en/ask  or

1. Run the app locally (env vars from the [previous PR](ttps://github.com/voorhoede/head-start/pull/379) need to be set).
2. Visit `/en/ask/`. Ask something the site would know about. You should see "Thinking…", then the answer appear word by word, with the sources it used.
3. Try a deep link like `/en/ask/?query=How%20do%20I%20add%20a%20new%20locale%3F`. It should run on its own.
4. Check the item is in header nav: "Ask AI" 



## Checklist

- [x] Self-reviewed
- [x] Easy to review (one component, one page, one nav link)
- [ ] Notified a reviewer
