### PR TITLE
feat: add Link response headers for agent discovery (RFC 8288)

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -11,6 +11,7 @@
   X-Content-Type-Options: nosniff
   Content-Security-Policy: frame-ancestors 'self' https://*.admin.datocms.com https://plugins-cdn.datocms.com
   X-XSS-Protection: 1; mode=block
+  Link: </llms.txt>; rel="describedby"; type="text/plain"
 
 # Allow DatoCMS to embed the editor-guide page in an iframe
 /cms/editor-guide/

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -2,6 +2,7 @@ import {  sequence } from 'astro:middleware';
 
 import { datocms } from './datocms';
 import { i18n } from './i18n';
+import { linkheaders } from './link-headers';
 import { preview } from './preview';
 import { proxyFiles } from './proxy-files';
 import { redirects } from './redirects';
@@ -14,4 +15,5 @@ export const onRequest = sequence(
   proxyFiles,
   redirects,
   securityheaders,
+  linkheaders,
 );

--- a/src/middleware/link-headers.ts
+++ b/src/middleware/link-headers.ts
@@ -1,0 +1,23 @@
+import { defineMiddleware } from 'astro:middleware';
+
+/**
+ * Link Headers (RFC 8288):
+ * Advertise machine-readable resources to agents and crawlers via the `Link`
+ * response header. `/llms.txt` is a plain-text description of the site for LLMs,
+ * exposed here with the registered `describedby` relation type.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc8288 (Web Linking)
+ * @see https://www.iana.org/assignments/link-relations/link-relations.xhtml
+ *
+ * ⚠️ These headers are only applied to runtime responses, so keep these rules in sync
+ *    with their static counterparts in public/_headers
+ */
+const linkHeader = '</llms.txt>; rel="describedby"; type="text/plain"';
+
+export const linkheaders = defineMiddleware(async (context, next) => {
+  const response = await next();
+  if (!response.headers.has('Link')) {
+    response.headers.set('Link', linkHeader);
+  }
+  return response;
+});

--- a/src/middleware/tests/link-headers.test.ts
+++ b/src/middleware/tests/link-headers.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { APIContext } from 'astro';
+import { linkheaders } from '../link-headers';
+
+describe('linkheaders middleware', () => {
+  it('adds a Link header advertising llms.txt via describedby', async () => {
+    const mockContext = {
+      request: new Request('https://example.com'),
+      url: new URL('https://example.com'),
+      params: {},
+    } as APIContext;
+
+    const next = vi.fn().mockResolvedValue(new Response('OK'));
+
+    const finalResponse = await linkheaders(mockContext, next);
+
+    expect(finalResponse).toBeInstanceOf(Response);
+    expect(finalResponse?.headers.get('Link')).toBe(
+      '</llms.txt>; rel="describedby"; type="text/plain"',
+    );
+  });
+
+  it('does not override an existing Link header', async () => {
+    const mockContext = {
+      request: new Request('https://example.com'),
+      url: new URL('https://example.com'),
+      params: {},
+    } as APIContext;
+
+    const response = new Response('OK', {
+      headers: { Link: '</custom>; rel="preload"' },
+    });
+    const next = vi.fn().mockResolvedValue(response);
+
+    const finalResponse = await linkheaders(mockContext, next);
+
+    expect(finalResponse?.headers.get('Link')).toBe('</custom>; rel="preload"');
+  });
+});


### PR DESCRIPTION
# Changes

- Adds an RFC 8288 `Link` response header advertising `/llms.txt` to agents and crawlers, using the registered `describedby` relation type
- New `link-headers` middleware for runtime responses (covers the root `/` redirect and SSR/preview responses)
- Adds the same header statically in `public/_headers` (covers prerendered locale homepages), matching the existing `security-headers` pattern
- Adds unit tests for the middleware

# Associated issue

<!-- Resolves #(ticket number) -->

External requirement: [isitagentready.com link-headers skill](https://isitagentready.com/.well-known/agent-skills/link-headers/SKILL.md), per [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288) and [RFC 9727 §3](https://www.rfc-editor.org/rfc/rfc9727#section-3).

# How to test

1. Open the preview link
2. Request the root URL and a locale homepage, e.g. `curl -sI https://<preview>/` and `curl -sI https://<preview>/en/`
3. Verify each response includes: `Link: </llms.txt>; rel="describedby"; type="text/plain"`
4. Confirm `/llms.txt` resolves and returns the site's plain-text LLM description
5. (Optional) Validate: `POST https://isitagentready.com/api/scan` with `{"url":"https://<preview>"}` and check `checks.discoverability.linkHeaders.status` is `"pass"`

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] ~I have made updated relevant documentation files (in project README, docs/, etc)~
- [x] ~I have added a decision log entry if the change affects the architecture or changes a significant technology~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
