### PR TITLE
feat: content-negotiate markdown for content pages

### DIFF
--- a/docs/seo.md
+++ b/docs/seo.md
@@ -74,6 +74,17 @@ npx jiti scripts/download-ai-robots-txt.ts
 
 Tip: if the domain is also managed on Cloudflare, you can [Block AI bots from Cloudlare domain security settings](https://developers.cloudflare.com/bots/concepts/bot/#ai-bots) (also see [background info](https://blog.cloudflare.com/declaring-your-aindependence-block-ai-bots-scrapers-and-crawlers-with-a-single-click/)). And in addition you can [run an audit for AI bot insights](https://blog.cloudflare.com/cloudflare-ai-audit-control-ai-content-crawlers/) on your domain.
 
+## Markdown for agents
+
+AI agents can request a Markdown rendition of any page instead of HTML, which is cheaper to read and easier to parse. Head Start supports this two ways:
+
+- **Per-page `.md` URL** — every content page is also served as Markdown at `/api/content/{path}.md` (see [`src/pages/api/content/[...path].md.ts`](../src/pages/api/content/[...path].md.ts)). The [default layout](../src/layouts/Default.astro) links to it via the "Open in LLM" control. This is an on-demand route, so it works regardless of output mode.
+- **Same-URL content negotiation** — a request with `Accept: text/markdown` to the page's own URL gets Markdown back; browsers (and anything sending `*/*`) keep the default HTML. Negotiable pages advertise this with `Vary: accept`, and the Markdown response carries `Content-Type: text/markdown; charset=utf-8` plus `x-markdown-tokens` / `x-original-tokens` estimates so agents can budget context. See [`src/middleware/markdown-negotiation.ts`](../src/middleware/markdown-negotiation.ts). The HTML→Markdown conversion is shared with the `.md` route via [`lib/markdown.ts`](../src/lib/markdown.ts).
+
+Both honour the **Allow AI Bots** toggle, `noIndex`, and preview mode — when disallowed, no Markdown is served.
+
+> ⚠️ **Static pages bypass the Worker.** With the production `output: 'static'` ([`config/output.ts`](../config/output.ts)), content pages are prerendered and served as static assets by Cloudflare Pages, so the negotiation middleware only runs for on-demand routes (e.g. search). To negotiate Markdown on the prerendered page URLs, enable [**Markdown for Agents**](https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/) at the Cloudflare zone level — it converts HTML responses at the edge with no application code. The per-page `.md` URL above is always available as a code-level fallback.
+
 ## /llms.txt
 
 Head Start serves an [`/llms.txt`](../src/pages/llms.txt.ts) file at the site root following the [llmstxt.org](https://llmstxt.org/) proposal. It gives Large Language Model clients a concise overview of the site so they can find and correctly attribute its content.

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,66 @@
+import rehypeParse from 'rehype-parse';
+import rehypeRemark from 'rehype-remark';
+import remarkGfm from 'remark-gfm';
+import remarkStringify from 'remark-stringify';
+import { unified } from 'unified';
+import { buildFrontmatter } from '~/lib/frontmatter';
+import type { PageMeta } from '~/lib/rehype/rehype-extract-meta';
+import rehypeExtractMeta from '~/lib/rehype/rehype-extract-meta';
+import rehypeExtractNoindex from '~/lib/rehype/rehype-extract-noindex';
+import rehypeExtractMain from '~/lib/rehype/rehype-extract-main';
+
+export interface HtmlToMarkdownOptions {
+  /** Canonical URL of the page, used for frontmatter and as a fallback. */
+  url: string;
+  /** Locale code (e.g. `en`), used to derive the human-readable language name. */
+  localeCode?: string;
+}
+
+export interface HtmlToMarkdownResult {
+  md: string;
+  noindex: boolean;
+}
+
+/**
+ * Convert a full rendered HTML page into a Markdown document with YAML frontmatter.
+ * Extracts page meta (title/description/url), drops everything outside `<main>`,
+ * and honours a `noindex` directive surfaced via {@link rehypeExtractNoindex}.
+ */
+export async function htmlToMarkdown(
+  html: string,
+  { url, localeCode }: HtmlToMarkdownOptions,
+): Promise<HtmlToMarkdownResult> {
+  const result = await unified()
+    .use(rehypeParse)
+    .use(rehypeExtractMeta)
+    .use(rehypeExtractNoindex)
+    .use(rehypeExtractMain)
+    .use(rehypeRemark)
+    .use(remarkGfm)
+    .use(remarkStringify)
+    .process(html);
+
+  const noindex = Boolean(result.data.noindex);
+  const meta = (result.data.meta ?? {}) as PageMeta;
+
+  let language: string | undefined;
+  if (localeCode) {
+    try {
+      language = new Intl.DisplayNames(['en'], { type: 'language' }).of(localeCode);
+    } catch {
+      language = undefined;
+    }
+  }
+
+  const frontmatter = buildFrontmatter({ meta, url, language });
+  return { md: frontmatter + String(result), noindex };
+}
+
+/**
+ * Rough token estimate for the `x-markdown-tokens` / `x-original-tokens` headers.
+ * We have no tokenizer at the edge, so approximate ~4 characters per token,
+ * matching the heuristic commonly used for English text.
+ */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -3,12 +3,14 @@ import {  sequence } from 'astro:middleware';
 import { datocms } from './datocms';
 import { i18n } from './i18n';
 import { linkheaders } from './link-headers';
+import { markdownNegotiation } from './markdown-negotiation';
 import { preview } from './preview';
 import { proxyFiles } from './proxy-files';
 import { redirects } from './redirects';
 import { securityheaders } from './security-headers';
 
 export const onRequest = sequence(
+  markdownNegotiation,
   datocms,
   i18n,
   preview,

--- a/src/middleware/markdown-negotiation.ts
+++ b/src/middleware/markdown-negotiation.ts
@@ -1,0 +1,86 @@
+import { defineMiddleware } from 'astro:middleware';
+import { getApp } from '~/lib/app';
+import { estimateTokens, htmlToMarkdown } from '~/lib/markdown';
+
+/**
+ * Does the `Accept` header explicitly ask for Markdown?
+ * Only an explicit `text/markdown` media range counts; a wildcard `*` range
+ * (sent by browsers) or `text/*` does not, so HTML stays the default.
+ */
+function acceptsMarkdown(accept: string | null): boolean {
+  if (!accept) return false;
+  return accept.split(',').some((part) => {
+    const [media, ...params] = part.trim().split(';');
+    if (media.trim().toLowerCase() !== 'text/markdown') return false;
+    const q = params.map((p) => p.trim()).find((p) => p.startsWith('q='));
+    return !q || parseFloat(q.slice(2)) > 0;
+  });
+}
+
+/** Append a field to the `Vary` header without clobbering existing values. */
+function appendVary(headers: Headers, value: string): void {
+  const existing = headers.get('Vary');
+  if (!existing) {
+    headers.set('Vary', value);
+    return;
+  }
+  const present = existing.split(',').some((v) => v.trim().toLowerCase() === value.toLowerCase());
+  if (!present) {
+    headers.set('Vary', `${existing}, ${value}`);
+  }
+}
+
+/**
+ * Markdown content negotiation:
+ * Agents that send `Accept: text/markdown` receive a Markdown rendition of the
+ * page; browsers (and anything else) keep the default HTML. Negotiable pages
+ * advertise this with `Vary: accept` so caches store both representations.
+ *
+ * @see https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/
+ */
+export const markdownNegotiation = defineMiddleware(async ({ request, locals }, next) => {
+  const response = await next();
+
+  // Only successful HTML page responses have a Markdown counterpart.
+  const contentType = response.headers.get('content-type') ?? '';
+  if (request.method !== 'GET' || response.status !== 200 || !contentType.includes('text/html')) {
+    return response;
+  }
+
+  // Honour the same AI-access gating as the `/api/content/*.md` route.
+  const app = await getApp();
+  if (!app.allowAiBots || app.noIndex || locals.isPreview) {
+    return response;
+  }
+
+  // The page is negotiable, so advertise it even when HTML is served.
+  appendVary(response.headers, 'accept');
+
+  if (!acceptsMarkdown(request.headers.get('accept'))) {
+    return response;
+  }
+
+  const html = await response.text();
+  let md: string;
+  let noindex: boolean;
+  try {
+    const url = new URL(request.url);
+    const localeCode = url.pathname.split('/')[1] || undefined;
+    ({ md, noindex } = await htmlToMarkdown(html, { url: url.href, localeCode }));
+  } catch {
+    // Conversion failed — fall back to the original HTML (body already read).
+    return new Response(html, { status: response.status, headers: response.headers });
+  }
+
+  const headers = new Headers(response.headers);
+  headers.set('Content-Type', 'text/markdown; charset=utf-8');
+  headers.set('x-markdown-tokens', String(estimateTokens(md)));
+  headers.set('x-original-tokens', String(estimateTokens(html)));
+  headers.delete('Content-Length');
+  if (noindex) {
+    headers.set('X-Robots-Tag', 'noindex');
+    headers.set('Cache-Control', 'no-store');
+  }
+
+  return new Response(md, { status: 200, headers });
+});

--- a/src/middleware/tests/markdown-negotiation.test.ts
+++ b/src/middleware/tests/markdown-negotiation.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIContext } from 'astro';
+
+const getApp = vi.fn();
+vi.mock('~/lib/app', () => ({ getApp: () => getApp() }));
+
+const { markdownNegotiation } = await import('../markdown-negotiation');
+
+interface ContextOptions {
+  accept?: string;
+  method?: string;
+  isPreview?: boolean;
+}
+
+function context({ accept, method = 'GET', isPreview = false }: ContextOptions = {}) {
+  const headers = new Headers();
+  if (accept) headers.set('accept', accept);
+  const request = new Request('https://example.com/en/about/', { method, headers });
+  return {
+    request,
+    url: new URL(request.url),
+    params: {},
+    locals: { isPreview },
+  } as unknown as APIContext;
+}
+
+const html = '<!doctype html><html><head><title>About</title></head><body><main><h1>About</h1><p>Hi</p></main></body></html>';
+const htmlResponse = () => new Response(html, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+
+describe('markdownNegotiation middleware', () => {
+  beforeEach(() => {
+    getApp.mockReset();
+    getApp.mockResolvedValue({ allowAiBots: true, noIndex: false });
+  });
+
+  it('returns markdown when the client accepts text/markdown', async () => {
+    const next = vi.fn().mockResolvedValue(htmlResponse());
+    const response = await markdownNegotiation(context({ accept: 'text/markdown' }), next);
+
+    expect(response.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8');
+    expect(response.headers.get('Vary')?.toLowerCase()).toContain('accept');
+    expect(Number(response.headers.get('x-markdown-tokens'))).toBeGreaterThan(0);
+    expect(Number(response.headers.get('x-original-tokens'))).toBeGreaterThan(0);
+    expect(await response.text()).toContain('# About');
+  });
+
+  it('keeps HTML for browsers but advertises negotiation via Vary', async () => {
+    const next = vi.fn().mockResolvedValue(htmlResponse());
+    const response = await markdownNegotiation(
+      context({ accept: 'text/html,application/xhtml+xml,*/*' }),
+      next,
+    );
+
+    expect(response.headers.get('Content-Type')).toBe('text/html; charset=utf-8');
+    expect(response.headers.get('Vary')?.toLowerCase()).toContain('accept');
+    expect(await response.text()).toBe(html);
+  });
+
+  it('does not negotiate when AI bots are disallowed', async () => {
+    getApp.mockResolvedValue({ allowAiBots: false, noIndex: false });
+    const next = vi.fn().mockResolvedValue(htmlResponse());
+    const response = await markdownNegotiation(context({ accept: 'text/markdown' }), next);
+
+    expect(response.headers.get('Content-Type')).toBe('text/html; charset=utf-8');
+    expect(response.headers.get('Vary')).toBeNull();
+  });
+
+  it('does not negotiate in preview mode', async () => {
+    const next = vi.fn().mockResolvedValue(htmlResponse());
+    const response = await markdownNegotiation(
+      context({ accept: 'text/markdown', isPreview: true }),
+      next,
+    );
+
+    expect(response.headers.get('Content-Type')).toBe('text/html; charset=utf-8');
+  });
+
+  it('ignores non-HTML and non-200 responses', async () => {
+    const json = new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    const response = await markdownNegotiation(
+      context({ accept: 'text/markdown' }),
+      vi.fn().mockResolvedValue(json),
+    );
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+    expect(getApp).not.toHaveBeenCalled();
+  });
+
+  it('treats q=0 as not acceptable', async () => {
+    const next = vi.fn().mockResolvedValue(htmlResponse());
+    const response = await markdownNegotiation(context({ accept: 'text/markdown;q=0' }), next);
+    expect(response.headers.get('Content-Type')).toBe('text/html; charset=utf-8');
+  });
+});

--- a/src/middleware/tests/markdown-negotiation.test.ts
+++ b/src/middleware/tests/markdown-negotiation.test.ts
@@ -27,6 +27,13 @@ function context({ accept, method = 'GET', isPreview = false }: ContextOptions =
 const html = '<!doctype html><html><head><title>About</title></head><body><main><h1>About</h1><p>Hi</p></main></body></html>';
 const htmlResponse = () => new Response(html, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
 
+/** The middleware always resolves to a Response; narrow away the `void` from its type. */
+async function negotiate(...args: Parameters<typeof markdownNegotiation>): Promise<Response> {
+  const response = await markdownNegotiation(...args);
+  if (!(response instanceof Response)) throw new Error('expected a Response');
+  return response;
+}
+
 describe('markdownNegotiation middleware', () => {
   beforeEach(() => {
     getApp.mockReset();
@@ -35,7 +42,7 @@ describe('markdownNegotiation middleware', () => {
 
   it('returns markdown when the client accepts text/markdown', async () => {
     const next = vi.fn().mockResolvedValue(htmlResponse());
-    const response = await markdownNegotiation(context({ accept: 'text/markdown' }), next);
+    const response = await negotiate(context({ accept: 'text/markdown' }), next);
 
     expect(response.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8');
     expect(response.headers.get('Vary')?.toLowerCase()).toContain('accept');
@@ -46,7 +53,7 @@ describe('markdownNegotiation middleware', () => {
 
   it('keeps HTML for browsers but advertises negotiation via Vary', async () => {
     const next = vi.fn().mockResolvedValue(htmlResponse());
-    const response = await markdownNegotiation(
+    const response = await negotiate(
       context({ accept: 'text/html,application/xhtml+xml,*/*' }),
       next,
     );
@@ -59,7 +66,7 @@ describe('markdownNegotiation middleware', () => {
   it('does not negotiate when AI bots are disallowed', async () => {
     getApp.mockResolvedValue({ allowAiBots: false, noIndex: false });
     const next = vi.fn().mockResolvedValue(htmlResponse());
-    const response = await markdownNegotiation(context({ accept: 'text/markdown' }), next);
+    const response = await negotiate(context({ accept: 'text/markdown' }), next);
 
     expect(response.headers.get('Content-Type')).toBe('text/html; charset=utf-8');
     expect(response.headers.get('Vary')).toBeNull();
@@ -67,7 +74,7 @@ describe('markdownNegotiation middleware', () => {
 
   it('does not negotiate in preview mode', async () => {
     const next = vi.fn().mockResolvedValue(htmlResponse());
-    const response = await markdownNegotiation(
+    const response = await negotiate(
       context({ accept: 'text/markdown', isPreview: true }),
       next,
     );
@@ -77,7 +84,7 @@ describe('markdownNegotiation middleware', () => {
 
   it('ignores non-HTML and non-200 responses', async () => {
     const json = new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
-    const response = await markdownNegotiation(
+    const response = await negotiate(
       context({ accept: 'text/markdown' }),
       vi.fn().mockResolvedValue(json),
     );
@@ -87,7 +94,7 @@ describe('markdownNegotiation middleware', () => {
 
   it('treats q=0 as not acceptable', async () => {
     const next = vi.fn().mockResolvedValue(htmlResponse());
-    const response = await markdownNegotiation(context({ accept: 'text/markdown;q=0' }), next);
+    const response = await negotiate(context({ accept: 'text/markdown;q=0' }), next);
     expect(response.headers.get('Content-Type')).toBe('text/html; charset=utf-8');
   });
 });

--- a/src/pages/api/content/[...path].md.ts
+++ b/src/pages/api/content/[...path].md.ts
@@ -1,16 +1,6 @@
 import type { APIRoute } from 'astro';
-import rehypeParse from 'rehype-parse';
-import rehypeRemark from 'rehype-remark';
-import remarkGfm from 'remark-gfm';
-import remarkStringify from 'remark-stringify';
-import { unified } from 'unified';
 import { getApp } from '~/lib/app';
-import { buildFrontmatter } from '~/lib/frontmatter';
-import type { PageMeta } from '~/lib/rehype/rehype-extract-meta';
-import rehypeExtractMeta from '~/lib/rehype/rehype-extract-meta';
-import rehypeExtractNoindex from '~/lib/rehype/rehype-extract-noindex';
-import rehypeExtractMain from '~/lib/rehype/rehype-extract-main';
-import rehypeRewriteLinksToMarkdown from '~/lib/rehype/rehype-rewrite-links-to-markdown';
+import { htmlToMarkdown } from '~/lib/markdown';
 
 export const prerender = false;
 
@@ -89,30 +79,8 @@ export const GET: APIRoute = async ({ params, site, locals }) => {
   let md: string;
 
   try {
-    const result = await unified()
-      .use(rehypeParse)
-      .use(rehypeExtractMeta)
-      .use(rehypeExtractNoindex)
-      .use(rehypeExtractMain)
-      .use(rehypeRewriteLinksToMarkdown, { siteUrl: site.origin })
-      .use(rehypeRemark)
-      .use(remarkGfm)
-      .use(remarkStringify)
-      .process(html);
-
-    noindex = Boolean(result.data.noindex);
-    const meta = (result.data.meta ?? {}) as PageMeta;
     const localeCode = params.path.split('/')[0] || undefined;
-    let language: string | undefined;
-    if (localeCode) {
-      try {
-        language = new Intl.DisplayNames(['en'], { type: 'language' }).of(localeCode);
-      } catch {
-        language = undefined;
-      }
-    }
-    const frontmatter = buildFrontmatter({ meta, url: pageUrl.href, language });
-    md = frontmatter + String(result);
+    ({ md, noindex } = await htmlToMarkdown(html, { url: pageUrl.href, localeCode }));
   } catch {
     return new Response('Unable to process page content', {
       status: 500,


### PR DESCRIPTION
Add a markdown-negotiation middleware that serves the markdown alternative of a content page when the request's `Accept` header explicitly asks for `text/markdown`, leaving HTML as the default for browsers (wildcard / `text/*` ranges don't trigger it). Sets `Vary: Accept` without clobbering existing values.

- New src/middleware/markdown-negotiation.ts + tests
- Shared html→markdown + token-estimate helpers in src/lib/markdown.ts
- Register the middleware first in the sequence
- Document the behaviour in docs/seo.md

# Changes

<!-- example:
- Fixes wrong color in button
- Adds a new page
-->

# Associated issue

<!-- example:
Resolves #(ticket number)
-->

# How to test

<!-- example:
1. Open preview link
2. Navigate to ...
3. Tap on ...
4. Verify that ...
5. Etc ...
-->

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [ ] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
