### PR TITLE
feature: declare AI content usage preferences via Content Signals in robots.txt

### DIFF
--- a/src/lib/seo/index.test.ts
+++ b/src/lib/seo/index.test.ts
@@ -117,6 +117,27 @@ describe('seo', () => {
     expect(robots.getSitemaps()).toEqual([`${siteUrl}/sitemap-index.xml`]);
   });
 
+  test('robots.txt declares a Content-Signal in the User-agent: * block', () => {
+    const result = robotsTxt({ allowAiBots: true, allowAll: true, siteUrl: 'https://example.com' });
+    const userAgentBlock = result.slice(result.indexOf('User-agent: *'));
+    expect(userAgentBlock).toMatch(/^Content-Signal: .+$/m);
+  });
+
+  test('robots.txt Content-Signal grants all uses when AI bots and indexing are allowed', () => {
+    const result = robotsTxt({ allowAiBots: true, allowAll: true, siteUrl: 'https://example.com' });
+    expect(result).toContain('Content-Signal: ai-train=yes, search=yes, ai-input=yes');
+  });
+
+  test('robots.txt Content-Signal denies AI uses but keeps search when AI bots are disallowed', () => {
+    const result = robotsTxt({ allowAiBots: false, allowAll: true, siteUrl: 'https://example.com' });
+    expect(result).toContain('Content-Signal: ai-train=no, search=yes, ai-input=no');
+  });
+
+  test('robots.txt Content-Signal denies all uses when indexing is disallowed', () => {
+    const result = robotsTxt({ allowAiBots: false, allowAll: false, siteUrl: 'https://example.com' });
+    expect(result).toContain('Content-Signal: ai-train=no, search=no, ai-input=no');
+  });
+
   test('llmsTxt renders H1, blockquote, intro and Pages section when AI bots are allowed', () => {
     const result = llmsTxt({
       siteName: 'Acme',

--- a/src/lib/seo/index.ts
+++ b/src/lib/seo/index.ts
@@ -33,10 +33,24 @@ export type RobotsTxtProps = {
   siteUrl: string,
 };
 
+/**
+  * Content Signals declare how content may be used by automated clients,
+  * independently from crawl access (Allow/Disallow). We tie the preferences to
+  * the site's existing config: `search` follows general indexing access
+  * (`allowAll`), while `ai-train` and `ai-input` follow the AI bots preference
+  * (`allowAiBots`).
+  * @see https://contentsignals.org/
+  */
+const contentSignal = ({ allowAiBots, allowAll }: Pick<RobotsTxtProps, 'allowAiBots' | 'allowAll'>) => {
+  const yesNo = (value: boolean) => (value ? 'yes' : 'no');
+  return `Content-Signal: ai-train=${yesNo(allowAiBots)}, search=${yesNo(allowAll)}, ai-input=${yesNo(allowAiBots)}`;
+};
+
 export const robotsTxt = ({ allowAiBots, allowAll, siteUrl }: RobotsTxtProps) => `
 ${allowAiBots ? '' : aiRobotsTxt}
 
 User-agent: *
+${contentSignal({ allowAiBots, allowAll })}
 ${allowAll ? 'Allow: /' : 'Disallow: /'}
 
 Sitemap: ${siteUrl}/sitemap-index.xml


### PR DESCRIPTION
# Changes

- Adds a `Content-Signal` directive to the `User-agent: *` block of `robots.txt`, declaring AI content usage preferences for `ai-train`, `search` and `ai-input` ([contentsignals.org](https://contentsignals.org/))
- Values are derived from existing site config rather than hardcoded: `search` follows general indexing access (`allowAll`), while `ai-train` and `ai-input` follow the AI bots preference (`allowAiBots`)
- Adds unit tests covering the directive placement and value combinations

Example output:
- AI bots + indexing on → `Content-Signal: ai-train=yes, search=yes, ai-input=yes`
- AI bots off, indexing on → `Content-Signal: ai-train=no, search=yes, ai-input=no`
- indexing off → `Content-Signal: ai-train=no, search=no, ai-input=no`

# Associated issue

<!-- Resolves #(ticket number) -->
No Content Signals found in robots.txt.

# How to test

1. Run `npx vitest run src/lib/seo/index.test.ts` — all tests pass
2. Open the deployed preview at `/robots.txt`
3. Verify the `User-agent: *` block contains a `Content-Signal:` line with `ai-train`, `search` and `ai-input` values matching the site's CMS config (AI bots / indexing toggles)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] ~~I have made updated relevant documentation files (in project README, docs/, etc)~~ — no docs affected
- [ ] ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~ — no architectural change
- [x] I have notified a reviewer
