### PR TITLE
feature: serve agents index for DNS-AID agent discovery

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -128,6 +128,21 @@ You're project is now deployed and will automatically be deployed on every git c
 
 That's it. Now deployments are automatically triggered from both git and when editors hit 'Build now' in the CMS. If you add additional build triggers in the future, you can repeat those steps. Note that `buildTriggerId` in `/datocms-environment.ts` should always be set to the production build trigger.
 
+## Enable AI agent discovery (DNS-AID) (optional)
+
+Head Start serves an agent registry at [`/.well-known/agents/index.json`](../src/pages/.well-known/agents/index.json.ts) (see [SEO → Agent discovery](./seo.md#agent-discovery-dns-aid)). To make it discoverable via [DNS for AI Discovery (DNS-AID)](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/), add DNS records on your own domain. This is optional and only applies once you use a custom domain on Cloudflare.
+
+1. **Publish DNS records.** In your Cloudflare DNS settings, add [`SVCB`/`HTTPS`](https://www.rfc-editor.org/rfc/rfc9460) records under `_agents.<domain>`. The `_index._agents.<domain>` record points clients to where the registry is served; service-specific records (e.g. `_a2a._agents.<domain>`) point to individual agents:
+
+   ```dns
+   _index._agents.example.com.  3600 IN SVCB 1 example.com. alpn="h2" port=443
+   _a2a._agents.example.com.    3600 IN SVCB 1 agent.example.com. alpn="a2a" port=443 mandatory=alpn,port
+   ```
+
+   Point the `_index` record's target (and `well-known` path, if used) at your site, so `_index._agents.<domain>` resolves to `/.well-known/agents/index.json`.
+
+2. **Enable DNSSEC.** Sign the zone so validating resolvers return authenticated data. On Cloudflare this is a [one-click setting](https://developers.cloudflare.com/dns/dnssec/) under DNS → Settings. This is the part a DNS-AID/DNSSEC audit checks — it cannot be set in application code.
+
 ## What's next?
 
 Read the [docs](../README.md#documentation) for more details on the setup Head Start provides.

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -141,7 +141,20 @@ The `agents` array is an **empty placeholder** by default. Per project, list the
   "name": "Head Start",
   "description": "Base setup on top of headless services to help you get started quickly",
   "url": "https://head-start.pages.dev",
-  "agents": []
+  "agents": [
+    // example of added agents
+    {
+      "name": "Site Search",
+      "description": "Searches Head Start's content and returns matching pages.",
+      "url": "https://head-start.pages.dev/api/agents/search",
+      "agentCard": "/.well-known/agent-card.json"
+    },
+    {
+      "name": "Booking Assistant",
+      "description": "Checks availability and books appointments.",
+      "url": "https://some-website.com/api/agents/booking"
+    }
+  ]
 }
 ```
 

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -152,7 +152,7 @@ The `agents` array is an **empty placeholder** by default. Per project, list the
     {
       "name": "Booking Assistant",
       "description": "Checks availability and books appointments.",
-      "url": "https://some-website.com/api/agents/booking"
+      "url": "https://example.com/api/agents/booking"
     }
   ]
 }

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -122,3 +122,27 @@ For commercial use, contact partnerships@yoursite.com
 - [GitHub](https://github.com/voorhoede)
 - [Website](https://voorhoede.nl/)
 ```
+
+## Agent discovery (DNS-AID)
+
+Head Start serves a machine-readable agent registry at [`/.well-known/agents/index.json`](../src/pages/.well-known/agents/index.json.ts), the HTTP counterpart to the [DNS for AI Discovery (DNS-AID)](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/) `_index._agents.<domain>` registry. It lets AI agents discover which agents (if any) an organisation exposes.
+
+The file is auto-generated at build time from:
+
+- `globalSeo.siteName` — used as `name`.
+- `globalSeo.fallbackSeo.description` — used as `description`.
+- The site URL — used as `url`.
+
+The `agents` array is an **empty placeholder** by default. Per project, list the agents your site exposes by passing them to [`agentsIndex()`](../src/lib/seo/index.ts) in the route, each with a `name`, `url`, and optional `agentCard` path (the [`/.well-known/agent-card.json`](https://www.rfc-editor.org/rfc/rfc8615) capability descriptor referenced by the DNS record's `well-known` parameter):
+
+```json
+{
+  "version": "0.1",
+  "name": "Head Start",
+  "description": "Base setup on top of headless services to help you get started quickly",
+  "url": "https://head-start.pages.dev",
+  "agents": []
+}
+```
+
+The registry JSON alone is **not discoverable** — a DNS-AID client finds it via DNS SVCB records, and those (plus DNSSEC signing) live in your DNS zone, not in this repo. See [Getting Started → Enable AI agent discovery](./getting-started.md#enable-ai-agent-discovery-dns-aid-optional) for the per-project DNS setup.

--- a/src/lib/seo/index.test.ts
+++ b/src/lib/seo/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, test, expect, vi } from 'vitest';
 import robotsParser from 'robots-parser';
-import { llmsTxt, robotsTxt, siteName, titleSuffix, titleTag } from '~/lib/seo';
+import { agentsIndex, llmsTxt, robotsTxt, siteName, titleSuffix, titleTag } from '~/lib/seo';
 import { getLocale } from '~/lib/i18n';
 import aiRobotsTxt from './ai.robots.txt?raw';
 
@@ -311,6 +311,39 @@ describe('seo', () => {
       ],
     });
     expect(result).toContain('## Top\n\n- Mid\n  - [Leaf](https://example.com/leaf/)');
+  });
+
+  test('agentsIndex builds a registry with an empty agents list by default', () => {
+    const result = agentsIndex({
+      siteName: 'Acme',
+      siteSummary: 'A short site description.',
+      siteUrl: 'https://example.com',
+    });
+    expect(result).toEqual({
+      version: '0.1',
+      name: 'Acme',
+      description: 'A short site description.',
+      url: 'https://example.com',
+      agents: [],
+    });
+  });
+
+  test('agentsIndex includes provided agents', () => {
+    const agents = [
+      {
+        name: 'Site search',
+        description: 'Search this site’s content',
+        url: 'https://example.com/api/search',
+        agentCard: '/.well-known/agent-card.json',
+      },
+    ];
+    const result = agentsIndex({
+      siteName: 'Acme',
+      siteSummary: '',
+      siteUrl: 'https://example.com',
+      agents,
+    });
+    expect(result.agents).toEqual(agents);
   });
 
 });

--- a/src/lib/seo/index.ts
+++ b/src/lib/seo/index.ts
@@ -69,6 +69,64 @@ const renderLlmsTxtItems = (items: LlmsTxtItem[], depth = 0): string[] => {
   });
 };
 
+export type AgentEntry = {
+  /** Human-readable name of the agent. */
+  name: string;
+  /** What the agent does. */
+  description?: string;
+  /** Endpoint where the agent can be reached. */
+  url: string;
+  /**
+   * Path (or URL) to the agent's A2A capability descriptor, i.e. the
+   * `/.well-known/agent-card.json` referenced by the DNS-AID SVCB record's
+   * `well-known` parameter. @see https://www.rfc-editor.org/rfc/rfc8615
+   */
+  agentCard?: string;
+};
+
+export type AgentsIndex = {
+  version: string;
+  name: string;
+  description: string;
+  url: string;
+  agents: AgentEntry[];
+};
+
+export type AgentsIndexProps = {
+  siteName: string;
+  siteSummary: string;
+  siteUrl: string;
+  agents?: AgentEntry[];
+};
+
+/**
+ * Machine-readable agent registry: the HTTP counterpart to the DNS-AID
+ * `_index._agents.<domain>` record (which returns a pointer to an
+ * organization-specific registry of all agents).
+ *
+ * IMPORTANT: authoritative DNS-AID discovery happens via SVCB/HTTPS DNS records
+ * under `_agents.<domain>` plus DNSSEC signing. Those live in your DNS zone
+ * (e.g. Cloudflare DNS) and cannot be served from this repo. This file is the
+ * registry those records can point a client to.
+ * @see https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/
+ * @see https://www.rfc-editor.org/rfc/rfc9460
+ *
+ * Minimal placeholder: `agents` is empty by default. Per project, pass the
+ * agents this site exposes (e.g. its search endpoint).
+ */
+export const agentsIndex = ({
+  siteName,
+  siteSummary,
+  siteUrl,
+  agents = [],
+}: AgentsIndexProps): AgentsIndex => ({
+  version: '0.1',
+  name: siteName,
+  description: siteSummary,
+  url: siteUrl,
+  agents,
+});
+
 export const llmsTxt = ({
   siteName,
   siteSummary,

--- a/src/pages/.well-known/agents/index.json.ts
+++ b/src/pages/.well-known/agents/index.json.ts
@@ -1,0 +1,30 @@
+// Web registry counterpart to the DNS-AID `_index._agents.<domain>` record.
+// Prerendered (build time) so site name/url come from project config, mirroring
+// `robots.txt.ts` and `llms.txt.ts`.
+//
+// NOTE: the actual DNS-AID discovery (SVCB/HTTPS DNS records under `_agents` +
+// DNSSEC signing) lives in your DNS zone (e.g. Cloudflare DNS), not in this repo.
+// @see https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/
+import type { APIRoute } from 'astro';
+import { defaultLocale } from '~/lib/i18n';
+import { globalSeo } from '~/lib/site.json';
+import { agentsIndex } from '~/lib/seo';
+
+export const prerender = true;
+
+export const GET: APIRoute = (context) => {
+  const seo = globalSeo[defaultLocale as keyof typeof globalSeo] ?? globalSeo;
+
+  return new Response(
+    JSON.stringify(
+      agentsIndex({
+        siteName: seo.siteName ?? '',
+        siteSummary: seo.fallbackSeo?.description ?? '',
+        siteUrl: context.site!.origin,
+      }),
+      null,
+      2,
+    ),
+    { headers: { 'content-type': 'application/json; charset=utf-8' } },
+  );
+};


### PR DESCRIPTION
# Changes

- Adds a build-time route serving `/.well-known/agents/index.json` — the HTTP counterpart to the DNS-AID `_index._agents.<domain>` registry (`src/pages/.well-known/agents/index.json.ts`, mirrors the `robots.txt.ts` / `llms.txt.ts` pattern)
- Adds `agentsIndex()` builder + `AgentEntry` / `AgentsIndex` types (`src/lib/seo/index.ts`)
- Adds unit tests (`src/lib/seo/index.test.ts`)

`name` + `description` come from DatoCMS `globalSeo` (via the build-time `site.json` snapshot, default locale). `url` resolves to the deploy domain via `siteUrl`. `agents` is an empty placeholder for each project to fill in (with optional `agentCard` path).

Example output:

```json
{
  "version": "0.1",
  "name": "Head Start",
  "description": "Base setup on top of headless services to help you get started quickly",
  "url": "https://head-start.pages.dev",
  "agents": []
}
```

**Why runtime, not `public/`:** static files hardcode the domain. As a per-project starter, head-start needs site name/URL injected at build — same reason `robots.txt` and `llms.txt` are routes.

**Out of scope (DNS-level, not this repo):** the authoritative DNS-AID discovery is DNS-zone config — SVCB/HTTPS records under `_agents.<domain>` plus DNSSEC signing. Those are set per-project in Cloudflare DNS. This PR provides the web registry those records can point at.

Refs: [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/), [RFC 9460 (SVCB/HTTPS)](https://www.rfc-editor.org/rfc/rfc9460)

# Associated issue

DNS-AID: "DNS for AI Discovery (DNS-AID) records found, but DNSSEC was not validated"

<!-- Resolves #(ticket number) -->

# How to test

1. Open the preview link
2. Navigate to `/.well-known/agents/index.json`
3. Verify valid JSON with `name` + `description` matching the site's DatoCMS SEO settings, `url` matching the deploy domain, and `agents: []`
4. Optionally run `npm run build` and confirm `dist/.well-known/agents/index.json` is emitted
5. Run `npx vitest run src/lib/seo/index.test.ts` — all pass

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have updated relevant documentation files (`docs/seo.md`, `docs/getting-started.md`)
- [ ] ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~ — no architectural change
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->

