### PR TITLE
Make migrations run on a fresh environment

### DIFF
--- a/config/datocms/migrations/1706210000_translations.ts
+++ b/config/datocms/migrations/1706210000_translations.ts
@@ -45,7 +45,6 @@ export default async function (client: Client) {
       addons: [],
       editor: 'single_line',
       parameters: { heading: true, placeholder: null },
-      type: 'title',
     },
     default_value: { en: '' },
   });

--- a/config/datocms/migrations/1706220000_pages.ts
+++ b/config/datocms/migrations/1706220000_pages.ts
@@ -248,7 +248,6 @@ export default async function (client: Client) {
       addons: [],
       editor: 'single_line',
       parameters: { heading: true, placeholder: null },
-      type: 'title',
     },
     default_value: { en: '' },
   });
@@ -315,7 +314,6 @@ export default async function (client: Client) {
       addons: [],
       editor: 'single_line',
       parameters: { heading: true, placeholder: null },
-      type: 'title',
     },
     default_value: { en: '' },
   });
@@ -520,7 +518,7 @@ export default async function (client: Client) {
     api_key: 'image',
     validators: {
       required: {},
-      extension: { extensions: [], predefined_list: 'image' },
+      extension: { predefined_list: 'image' },
       required_alt_title: { title: false, alt: true },
     },
     appearance: { addons: [], editor: 'file', parameters: {} },
@@ -561,7 +559,6 @@ export default async function (client: Client) {
       addons: [],
       editor: 'single_line',
       parameters: { heading: true, placeholder: null },
-      type: 'title',
     },
     default_value: { en: '' },
   });
@@ -995,7 +992,7 @@ export default async function (client: Client) {
     api_key: 'image',
     validators: {
       required: {},
-      extension: { extensions: [], predefined_list: 'image' },
+      extension: { predefined_list: 'image' },
       required_alt_title: { title: false, alt: true },
     },
     appearance: { addons: [], editor: 'file', parameters: {} },

--- a/config/datocms/migrations/1730405111_linkRecords.ts
+++ b/config/datocms/migrations/1730405111_linkRecords.ts
@@ -113,27 +113,24 @@ export default async function (client: Client) {
     notFoundMenuItem = menuItems.find(item => item.label === '\uD83E\uDD37 404 Page');
 
   if (
-    !schemaMigrationMenuItem ||
     !translationMenuItem ||
     !pagesMenuItem ||
     !homeMenuItem ||
     !notFoundMenuItem
   )
-    throw new Error(`Expected menu items to consist of: [
-    "Schema Migration", 
-    "Translation", 
-    "Pages", 
-    "Home", 
-    "404 Page", 
-    "Redirect Rules", 
-    "Image Block", 
-    "Table Block", and 
-    "Video Embed Block",
+    throw new Error(`Expected menu items to include: [
+    "🌐 Translation",
+    "📑 Pages",
+    "🏠 Home", and
+    "🤷 404 Page",
     ] but received: [
     ${menuItems.map(item => `    "${item.label}"`).join(',\n')}
     ]`);
 
-  await client.menuItems.destroy(schemaMigrationMenuItem.id);
+  // Only @datocms/cli v3 and below add a menu item for the schema migration
+  // model, so there is nothing to delete on newer versions.
+  if (schemaMigrationMenuItem)
+    await client.menuItems.destroy(schemaMigrationMenuItem.id);
 
   console.log('Update menu item "\uD83C\uDF10 Translations"');
   await client.menuItems.update(translationMenuItem.id, {

--- a/config/datocms/migrations/1735398092_emailAndPhoneLinks.ts
+++ b/config/datocms/migrations/1735398092_emailAndPhoneLinks.ts
@@ -123,7 +123,6 @@ export default async function (client: Client) {
       addons: [],
       editor: 'textarea',
       parameters: { placeholder: null },
-      type: 'textarea',
     },
     default_value: '',
   });
@@ -198,7 +197,6 @@ export default async function (client: Client) {
       addons: [],
       editor: 'textarea',
       parameters: { placeholder: null },
-      type: 'textarea',
     },
     default_value: '',
   });

--- a/config/datocms/migrations/1750900000_previewLinks.ts
+++ b/config/datocms/migrations/1750900000_previewLinks.ts
@@ -5,8 +5,18 @@ export default async function (client: Client) {
   console.log('Manage upload filters');
 
   console.log('Install plugin "Model Deployment Links"');
-  const previewApiToken = await createPreviewToken(client);
-  
+  // Plans with a low access token limit cannot create the "Preview" token.
+  // The plugin is still installed, but has to be configured manually then.
+  let previewApiToken: Awaited<ReturnType<typeof createPreviewToken>> | undefined;
+  try {
+    previewApiToken = await createPreviewToken(client);
+  } catch (error) {
+    console.warn(
+      'Could not create the "Preview" API token: %s\nSkipping configuration of the Model Deployment Links plugin. See docs/getting-started.md > "Configure DatoCMS plugins" to configure it manually.',
+      error instanceof Error ? error.message : error,
+    );
+  }
+
   // Check if plugin already exists
   const existingPlugins = await client.plugins.list();
   let plugin = existingPlugins.find((p) => p.package_name === 'datocms-plugin-model-deployment-links');
@@ -17,9 +27,11 @@ export default async function (client: Client) {
     });
   }
   
-  await client.plugins.update(plugin.id, {
-    parameters: { datoApiToken: previewApiToken.token },
-  });
+  if (previewApiToken) {
+    await client.plugins.update(plugin.id, {
+      parameters: { datoApiToken: previewApiToken.token },
+    });
+  }
 
   console.log('Creating new fields/fieldsets');
 

--- a/config/datocms/migrations/1773320919_featCounterBlock.ts
+++ b/config/datocms/migrations/1773320919_featCounterBlock.ts
@@ -1,6 +1,11 @@
 import { Client } from '@datocms/cli/lib/cma-client-node';
 
 export default async function (client: Client) {
+  // The Page and Home models are created without a fixed ID, so their ID
+  // differs per project. Look them up by API key instead of hardcoding it.
+  const page = await client.itemTypes.find('page');
+  const homePage = await client.itemTypes.find('home_page');
+
   console.log('Create new models/block models');
 
   console.log(
@@ -65,8 +70,8 @@ export default async function (client: Client) {
         on_reference_delete_strategy: 'delete_references',
         item_types: [
           'GjWw8t-hTFaYYWyc53FeIg',
-          'LjXdkuCdQxCFT4hv8_ayew',
-          'X_tZn3TxQY28ltSyjZUGHQ',
+          page.id,
+          homePage.id,
         ],
       },
     },

--- a/config/datocms/migrations/1774438799_featInlineVariableBlock.ts
+++ b/config/datocms/migrations/1774438799_featInlineVariableBlock.ts
@@ -1,6 +1,11 @@
 import { Client } from '@datocms/cli/lib/cma-client-node';
 
 export default async function (client: Client) {
+  // The Page and Home models are created without a fixed ID, so their ID
+  // differs per project. Look them up by API key instead of hardcoding it.
+  const page = await client.itemTypes.find('page');
+  const homePage = await client.itemTypes.find('home_page');
+
   console.log('Create new models/block models');
 
   console.log('Create model "\uD83D\uDD23 Variables" (`variable`)');
@@ -79,9 +84,9 @@ export default async function (client: Client) {
         on_reference_delete_strategy: 'delete_references',
         item_types: [
           'GjWw8t-hTFaYYWyc53FeIg',
-          'LjXdkuCdQxCFT4hv8_ayew',
+          page.id,
           'Weqp1brXRkSS-jZE8Z3HTw',
-          'X_tZn3TxQY28ltSyjZUGHQ',
+          homePage.id,
         ],
       },
     },
@@ -109,9 +114,9 @@ export default async function (client: Client) {
         on_reference_delete_strategy: 'delete_references',
         item_types: [
           'GjWw8t-hTFaYYWyc53FeIg',
-          'LjXdkuCdQxCFT4hv8_ayew',
+          page.id,
           'Weqp1brXRkSS-jZE8Z3HTw',
-          'X_tZn3TxQY28ltSyjZUGHQ',
+          homePage.id,
         ],
       },
     },

--- a/config/datocms/migrations/1774453728_featListBlock.ts
+++ b/config/datocms/migrations/1774453728_featListBlock.ts
@@ -1,6 +1,11 @@
 import { Client } from '@datocms/cli/lib/cma-client-node';
 
 export default async function (client: Client) {
+  // The Page and Home models are created without a fixed ID, so their ID
+  // differs per project. Look them up by API key instead of hardcoding it.
+  const page = await client.itemTypes.find('page');
+  const homePage = await client.itemTypes.find('home_page');
+
   console.log('Create new models/block models');
 
   console.log('Create block model "\uD83D\uDD22 List item" (`list_item`)');
@@ -57,9 +62,9 @@ export default async function (client: Client) {
         on_reference_delete_strategy: 'delete_references',
         item_types: [
           'GjWw8t-hTFaYYWyc53FeIg',
-          'LjXdkuCdQxCFT4hv8_ayew',
+          page.id,
           'Weqp1brXRkSS-jZE8Z3HTw',
-          'X_tZn3TxQY28ltSyjZUGHQ',
+          homePage.id,
         ],
       },
     },
@@ -167,9 +172,9 @@ export default async function (client: Client) {
         on_reference_delete_strategy: 'delete_references',
         item_types: [
           'GjWw8t-hTFaYYWyc53FeIg',
-          'LjXdkuCdQxCFT4hv8_ayew',
+          page.id,
           'Weqp1brXRkSS-jZE8Z3HTw',
-          'X_tZn3TxQY28ltSyjZUGHQ',
+          homePage.id,
         ],
       },
     },
@@ -242,9 +247,9 @@ export default async function (client: Client) {
         on_reference_delete_strategy: 'delete_references',
         item_types: [
           'GjWw8t-hTFaYYWyc53FeIg',
-          'LjXdkuCdQxCFT4hv8_ayew',
+          page.id,
           'Weqp1brXRkSS-jZE8Z3HTw',
-          'X_tZn3TxQY28ltSyjZUGHQ',
+          homePage.id,
         ],
       },
     },

--- a/config/datocms/migrations/1775222558_fixInlineVariableToBlock.ts
+++ b/config/datocms/migrations/1775222558_fixInlineVariableToBlock.ts
@@ -1,6 +1,14 @@
 import { Client } from '@datocms/cli/lib/cma-client-node';
 
 export default async function (client: Client) {
+  // The Page and Home models are created without a fixed ID, so their ID
+  // differs per project. Look them up by API key instead of hardcoding it.
+  const page = await client.itemTypes.find('page');
+  const homePage = await client.itemTypes.find('home_page');
+
+  // A localized default value has to cover exactly the locales of the project.
+  const { locales } = await client.site.find();
+
   console.log('Create new models/block models');
 
   console.log(
@@ -95,8 +103,8 @@ export default async function (client: Client) {
         on_reference_delete_strategy: 'delete_references',
         item_types: [
           'GjWw8t-hTFaYYWyc53FeIg',
-          'LjXdkuCdQxCFT4hv8_ayew',
-          'X_tZn3TxQY28ltSyjZUGHQ',
+          page.id,
+          homePage.id,
         ],
       },
     },
@@ -127,8 +135,8 @@ export default async function (client: Client) {
         on_reference_delete_strategy: 'delete_references',
         item_types: [
           'GjWw8t-hTFaYYWyc53FeIg',
-          'LjXdkuCdQxCFT4hv8_ayew',
-          'X_tZn3TxQY28ltSyjZUGHQ',
+          page.id,
+          homePage.id,
         ],
       },
     },
@@ -139,7 +147,9 @@ export default async function (client: Client) {
   );
   await client.fields.update('DihXGTqXQoia4qtLLVmuQA', {
     localized: true,
-    default_value: { en: null, nl: null },
+    default_value: Object.fromEntries(
+      locales.map((locale) => [locale, null]),
+    ),
   });
 
   console.log('Finalize models/block models');

--- a/config/datocms/migrations/1775648444_featInlineIconBlock.ts
+++ b/config/datocms/migrations/1775648444_featInlineIconBlock.ts
@@ -1,6 +1,11 @@
 import { Client } from '@datocms/cli/lib/cma-client-node';
 
 export default async function (client: Client) {
+  // The Page and Home models are created without a fixed ID, so their ID
+  // differs per project. Look them up by API key instead of hardcoding it.
+  const page = await client.itemTypes.find('page');
+  const homePage = await client.itemTypes.find('home_page');
+
   console.log('Create new models/block models');
 
   console.log('Create block model "\uD83D\uDE98 Icon Block" (`icon_block`)');
@@ -84,8 +89,8 @@ export default async function (client: Client) {
         on_reference_delete_strategy: 'delete_references',
         item_types: [
           'GjWw8t-hTFaYYWyc53FeIg',
-          'LjXdkuCdQxCFT4hv8_ayew',
-          'X_tZn3TxQY28ltSyjZUGHQ',
+          page.id,
+          homePage.id,
         ],
       },
     },
@@ -116,8 +121,8 @@ export default async function (client: Client) {
         on_reference_delete_strategy: 'delete_references',
         item_types: [
           'GjWw8t-hTFaYYWyc53FeIg',
-          'LjXdkuCdQxCFT4hv8_ayew',
-          'X_tZn3TxQY28ltSyjZUGHQ',
+          page.id,
+          homePage.id,
         ],
       },
     },

--- a/config/datocms/migrations/1776167107_featTableofContents.ts
+++ b/config/datocms/migrations/1776167107_featTableofContents.ts
@@ -6,7 +6,9 @@ export default async function (client: Client) {
   console.log(
     'Create Boolean field "Has Table of Contents" (`has_table_of_contents`) in model "\uD83D\uDCD1 Page" (`page`)',
   );
-  await client.fields.create('LjXdkuCdQxCFT4hv8_ayew', {
+  // The Page model is created without a fixed ID, so its ID differs per
+  // project. Target it by API key instead of hardcoding the ID.
+  await client.fields.create('page', {
     id: 'O1GwGpnqTO2dtee2OIhKyQ',
     label: 'Has Table of Contents',
     field_type: 'boolean',

--- a/config/datocms/migrations/1776267576_copyPageToLlm.ts
+++ b/config/datocms/migrations/1776267576_copyPageToLlm.ts
@@ -1,6 +1,11 @@
 import { Client } from '@datocms/cli/lib/cma-client-node';
 
 export default async function (client: Client) {
+  // A localized default value has to cover exactly the locales of the project,
+  // so only the primary locale gets the default prompt.
+  const { locales } = await client.site.find();
+  const [primaryLocale] = locales;
+
   console.log('Creating new fields/fieldsets');
 
   console.log(
@@ -27,10 +32,14 @@ export default async function (client: Client) {
       editor: 'single_line',
       parameters: { heading: false, placeholder: null },
     },
-    default_value: {
-      en: 'Read from this URL: { pageUrl } and explain it to me.',
-      nl: null,
-    },
+    default_value: Object.fromEntries(
+      locales.map((locale) => [
+        locale,
+        locale === primaryLocale
+          ? 'Read from this URL: { pageUrl } and explain it to me.'
+          : null,
+      ]),
+    ),
     fieldset: { id: 'ZOpXqRatSJ674Lw_5pn7ew', type: 'fieldset' },
   });
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,7 +77,9 @@ npm run dev
 
 Head Start comes with a few DatoCMS plugins pre-installed. The [Model Deployment Links plugin](https://www.datocms.com/marketplace/plugins/i/datocms-plugin-model-deployment-links) is configured automatically when running migrations. It adds preview links to the CMS sidebar so editors can preview pages directly from the CMS.
 
-If you need to configure the plugin manually (e.g. when not using migrations):
+The migration creates an access token named "Preview" for this. Plans with a limited number of access tokens do not allow this: the migration then logs a warning, installs the plugin unconfigured and continues. Preview links start working as soon as you configure the plugin yourself.
+
+If you need to configure the plugin manually (e.g. when not using migrations, or when the migration could not create the access token):
 
 - In your DatoCMS instance go to Project Settings > API Tokens (`/project_settings/access_tokens`) and "Add a new access token". Name it "Preview" (or whatever you prefer), for the "Role associated with this API token" select "Editor" and keep the other settings as is.
 - Go to Environment Configuration > Plugins > Model Deployment Links and enter the newly created access token in the plugin settings under "DatoCMS API Token".

--- a/src/lib/routing/index.test.ts
+++ b/src/lib/routing/index.test.ts
@@ -53,7 +53,7 @@ describe('getFileHref', () => {
 describe('getHomeHref', () => {
   test('returns the home href for a given locale', () => {
     expect(getHomeHref({ locale: 'en' })).toBe('/en/');
-    expect(getHomeHref({ locale: 'nl' })).toBe('/nl/');
+    expect(getHomeHref({ locale: 'nl' as SiteLocale })).toBe('/nl/');
   });
 
   test('returns the home href for current locale if no locale is provided', () => {

--- a/src/lib/search/index.test.ts
+++ b/src/lib/search/index.test.ts
@@ -5,6 +5,7 @@ import {
   getOpenSearchName,
   getOpenSearchPathname,
 } from '~/lib/search';
+import type { SiteLocale } from '~/lib/datocms/schema';
 
 vi.mock('~/lib/site.json', () => ({
   globalSeo: {
@@ -40,16 +41,16 @@ describe('search', () => {
 
   test('"getSearchPathname" should return correct search pathname for a specific locale', () => {
     expect(getSearchPathname('en')).toBe('/en/search/');
-    expect(getSearchPathname('nl')).toBe('/nl/search/');
+    expect(getSearchPathname('nl' as SiteLocale)).toBe('/nl/search/');
   });
 
   test('"getOpenSearchName" should return correct OpenSearch name for a specific locale', () => {
     expect(getOpenSearchName('en')).toBe('My Site (en)');
-    expect(getOpenSearchName('nl')).toBe('Mijn Website (nl)');
+    expect(getOpenSearchName('nl' as SiteLocale)).toBe('Mijn Website (nl)');
   });
 
   test('"getOpenSearchPathname" should return correct OpenSearch pathname for a specific locale', () => {
     expect(getOpenSearchPathname('en')).toBe('/en/search/opensearch.xml');
-    expect(getOpenSearchPathname('nl')).toBe('/nl/search/opensearch.xml');
+    expect(getOpenSearchPathname('nl' as SiteLocale)).toBe('/nl/search/opensearch.xml');
   });
 });

--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -2,11 +2,18 @@ import type { SiteLocale } from '~/lib/datocms/schema';
 import { getLocale } from '~/lib/i18n';
 import { globalSeo } from '~/lib/site.json';
 
+/**
+ * `globalSeo` is `null` in projects without SEO settings, and its per-locale
+ * keys are missing when only one locale is configured in Dato. Its inferred
+ * type therefore depends on the downloaded `site.json`, so we declare it here.
+ */
+const globalSeoByLocale = globalSeo as Record<string, { siteName?: string }> | null;
+
 export const queryParamName = 'query';
 export const minQueryLength = 3;
 export const hasValidQuery = (query: string) => (query.length >= minQueryLength);
 export const getSearchPathname = (locale: SiteLocale = getLocale()) => `/${ locale }/search/`;
-export const getOpenSearchName = (locale: SiteLocale = getLocale()) => `${globalSeo[locale as keyof typeof globalSeo]?.siteName} (${ locale })`;
+export const getOpenSearchName = (locale: SiteLocale = getLocale()) => `${globalSeoByLocale?.[locale]?.siteName} (${ locale })`;
 export const getOpenSearchPathname = (locale: SiteLocale) => `${ getSearchPathname(locale) }opensearch.xml`;
 
 // https://www.datocms.com/docs/site-search/excluding-text

--- a/src/lib/seo/index.test.ts
+++ b/src/lib/seo/index.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, test, expect, vi } from 'vitest';
 import robotsParser from 'robots-parser';
 import { agentsIndex, llmsTxt, robotsTxt, siteName, titleSuffix, titleTag } from '~/lib/seo';
+import type { SiteLocale } from '~/lib/datocms/schema';
 import { getLocale } from '~/lib/i18n';
 import aiRobotsTxt from './ai.robots.txt?raw';
 
@@ -31,7 +32,7 @@ describe('seo', () => {
     vi.mocked(getLocale).mockReturnValue('en');
     expect(siteName()).toBe('Test Site (English)');
 
-    vi.mocked(getLocale).mockReturnValue('nl');
+    vi.mocked(getLocale).mockReturnValue('nl' as SiteLocale);
     expect(siteName()).toBe('Test Site (Dutch)');
   });
 
@@ -39,7 +40,7 @@ describe('seo', () => {
     vi.mocked(getLocale).mockReturnValue('en');
     expect(titleSuffix()).toBe('| English Site');
 
-    vi.mocked(getLocale).mockReturnValue('nl');
+    vi.mocked(getLocale).mockReturnValue('nl' as SiteLocale);
     expect(titleSuffix()).toBe('| Nederlandse Site');
   });
 
@@ -50,7 +51,7 @@ describe('seo', () => {
       content: 'Test Page | English Site',
     });
 
-    vi.mocked(getLocale).mockReturnValue('nl');
+    vi.mocked(getLocale).mockReturnValue('nl' as SiteLocale);
     expect(titleTag('Testpagina')).toEqual({
       tag: 'title',
       content: 'Testpagina | Nederlandse Site',

--- a/src/lib/seo/index.ts
+++ b/src/lib/seo/index.ts
@@ -3,15 +3,18 @@ import { getLocale } from '~/lib/i18n';
 import { globalSeo } from '~/lib/site.json';
 import aiRobotsTxt from './ai.robots.txt?raw';
 
-/** 
+const emptySeo = { siteName: '', titleSuffix: '' };
+
+/**
   * `globalSeo` _should_ have a key per available locale. When there is only one
   * locale configured in Dato, that key is missing. Therefore we fallback to the
-  * `globalSeo` object 
+  * `globalSeo` object. A project without SEO settings has no `globalSeo` at all,
+  * in which case we fallback to empty strings.
   */
 const localeSeo = () => {
   const locale = getLocale();
-  const localeSeoData = globalSeo[locale as keyof typeof globalSeo];
-  return localeSeoData || globalSeo;
+  const localeSeoData = globalSeo?.[locale as keyof typeof globalSeo];
+  return localeSeoData || globalSeo || emptySeo;
 };
 
 export const siteName: () => string = () => localeSeo().siteName;


### PR DESCRIPTION
# Changes

Running the migrations against a new DatoCMS project failed on 5 separate points. All of them came down to migrations carrying values from the project they were generated against:

- Removed the legacy `type` key from `appearance` (the CMA rejects unknown keys now). `editor` already covered it.
- Replaced hardcoded Page/Home model IDs with lookups by API key. These models are created without a fixed ID, so their ID differs per project.
- Localized default values no longer hardcode an `nl` locale, they follow the project's locales.
- The `extension` validator no longer passes both `extensions` and `predefined_list`, which are mutually exclusive.
- Creating the "Preview" API token now fails softly, so projects on a plan with an access token limit can still run all migrations. The plugin is installed unconfigured and `getting-started.md` covers the manual step.

Updated `@datocms/cli` to v4 and `@datocms/cma-client-node` to v5 (was 3 majors behind). v4 no longer creates a menu item for the schema migration model, so deleting it is conditional now.

Last, `src/lib/seo` and `src/lib/search` assumed `globalSeo` exists, and the locale tests assumed the generated `SiteLocale` includes `nl`. Both depend on whichever environment you point at, so they break on any project that isn't exactly en+nl with global SEO filled in.

# Associated issue

<!-- none -->

# How to test

1. `npm run cms:environments:create` against a fresh project, run all migrations
2. All 27 should pass
3. `npm run lint:astro` and `npm run test:unit`

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] ~~I have added a decision log entry if the change affects the architecture or changes a significant technology~~
- [ ] I have notified a reviewer